### PR TITLE
I've implemented AudioSample Loading in AudioEngine.

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -30,7 +30,7 @@ juce_add_plugin(
 )
 
 # Sets the source files of the plugin project.
-set(SOURCE_FILES source/PluginEditor.cpp source/PluginProcessor.cpp)
+set(SOURCE_FILES source/PluginEditor.cpp source/PluginProcessor.cpp source/AudioEngine.cpp)
 # Optional; includes header files in the project file tree in Visual Studio
 set(HEADER_FILES ${INCLUDE_DIR}/PluginEditor.h ${INCLUDE_DIR}/PluginProcessor.h source/PointilismInterfaces.h)
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCE_FILES} ${HEADER_FILES})

--- a/plugin/source/AudioEngine.cpp
+++ b/plugin/source/AudioEngine.cpp
@@ -1,0 +1,63 @@
+#include "PointilismInterfaces.h" // For AudioEngine declaration
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_core/juce_core.h> // For DBG, juce::File
+
+// Implementation of loadAudioSample
+void AudioEngine::loadAudioSample(const juce::File& audioFile)
+{
+    juce::AudioFormatManager formatManager;
+    formatManager.registerBasicFormats(); // Register WAV and AIFF
+
+    // Create a reader for the audio file
+    // Note: juce::AudioFormatReader is an abstract class, store as a pointer.
+    // Using std::unique_ptr for automatic memory management is a good practice.
+    std::unique_ptr<juce::AudioFormatReader> reader(formatManager.createReaderFor(audioFile));
+
+    if (reader == nullptr)
+    {
+        DBG("Error loading audio file: " + audioFile.getFullPathName());
+        // Optionally, clear the sourceAudio buffer or handle the error in a more specific way
+        sourceAudio.setSize(0, 0); // Clear buffer on error
+        return;
+    }
+
+    // Resize the sourceAudio buffer to match the file's properties
+    // reader->numChannels gives the number of channels
+    // reader->lengthInSamples gives the total number of samples in the file
+    sourceAudio.setSize(static_cast<int>(reader->numChannels), static_cast<int>(reader->lengthInSamples));
+
+    // Read the audio data from the file into the sourceAudio buffer
+    // Parameters for reader->read:
+    // - targetBuffer: pointer to the buffer to fill (&sourceAudio)
+    // - startSampleInTargetBuffer: sample offset in the target buffer to start writing to (0)
+    // - numSamplesToRead: how many samples to read from the source (reader->lengthInSamples)
+    // - sourceSampleOffset: sample offset in the source file to start reading from (0)
+    // - fillLeftoversWithSilence: if true, fills remaining buffer with silence if source is shorter (true)
+    // - useStereoToMonoConversionIfNecessary: if true, converts stereo to mono if target is mono (true)
+    reader->read(
+        &sourceAudio,                               // Target buffer
+        0,                                          // Start sample in target buffer
+        static_cast<int>(reader->lengthInSamples),  // Number of samples to read
+        0,                                          // Start sample in source file
+        true,                                       // Fill leftovers with silence
+        true                                        // Use stereo to mono if necessary
+    );
+
+    // The std::unique_ptr will automatically delete the reader when it goes out of scope.
+    // No need for `delete reader;` if using std::unique_ptr.
+
+    DBG("Loaded audio file: " + audioFile.getFullPathName() +
+        ", Channels: " + juce::String(sourceAudio.getNumChannels()) +
+        ", Samples: " + juce::String(sourceAudio.getNumSamples()));
+}
+
+// Keep the other placeholder methods as they are for now
+void AudioEngine::prepareToPlay(double /*sampleRate*/, int /*samplesPerBlock*/)
+{
+    // TODO: Implementation if needed for this task or future tasks
+}
+
+void AudioEngine::processBlock(juce::AudioBuffer<float>& /*buffer*/, juce::MidiBuffer& /*midiMessages*/)
+{
+    // TODO: Implementation if needed for this task or future tasks
+}


### PR DESCRIPTION
I added the `AudioEngine::loadAudioSample` method to enable loading of audio samples (WAV and AIFF) from files you specify.

Key changes:
- I created `plugin/source/AudioEngine.cpp` with the implementation for `AudioEngine::loadAudioSample`.
- The method uses `juce::AudioFormatManager` to register basic audio formats and `juce::AudioFormatReader` to read audio file data.
- I included error handling: if a file cannot be read, a DBG message is printed, and the internal `sourceAudio` buffer is cleared.
- If successful, the `sourceAudio` buffer is resized to match the file's channel count and length, and the audio data is copied into it.
- I used `std::unique_ptr` for managing the `AudioFormatReader` to ensure proper memory deallocation.
- I updated `plugin/CMakeLists.txt` to include `AudioEngine.cpp` in the build.
- The `AudioEngine` class declaration and `sourceAudio` member were already present in `plugin/source/PointilismInterfaces.h`.