### PR TITLE
Implement grain lifecycle management in AudioEngine

### DIFF
--- a/plugin/source/AudioEngine.cpp
+++ b/plugin/source/AudioEngine.cpp
@@ -1,0 +1,56 @@
+#include "PointilismInterfaces.h"
+#include <vector>
+#include <algorithm> // Required for std::remove_if
+
+// Forward declaration of AudioEngine if not fully defined in PointilismInterfaces.h
+// Or ensure PointilismInterfaces.h has full class definition before this point.
+// Assuming PointilismInterfaces.h contains:
+// class AudioEngine {
+// public:
+//     void prepareToPlay(double sampleRate, int samplesPerBlock);
+//     // ... other members
+// private:
+//     std::vector<Grain> grains;
+//     // ... other members
+// };
+
+void AudioEngine::prepareToPlay(double /*sampleRate*/, int /*samplesPerBlock*/)
+{
+    grains.reserve(1024);
+}
+
+// Add the following method:
+void AudioEngine::triggerNewGrain()
+{
+    Grain newGrain;
+    newGrain.durationInSamples = 44100; // Default test value
+    newGrain.isAlive = true;
+    newGrain.ageInSamples = 0;
+    grains.push_back(newGrain);
+}
+
+// Add the following method:
+void AudioEngine::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /*midiMessages*/)
+{
+    const int numSamples = buffer.getNumSamples();
+
+    for (auto& grain : grains)
+    {
+        if (!grain.isAlive)
+            continue;
+
+        grain.ageInSamples += numSamples;
+
+        if (grain.ageInSamples >= grain.durationInSamples)
+        {
+            grain.isAlive = false;
+        }
+    }
+
+    grains.erase(
+        std::remove_if(grains.begin(), grains.end(), [](const Grain& grain) {
+            return !grain.isAlive;
+        }),
+        grains.end()
+    );
+}


### PR DESCRIPTION
This commit introduces the initial implementation for managing grain lifecycles within the AudioEngine class.

The following methods were added to AudioEngine.cpp:

- prepareToPlay: Pre-allocates memory for the grains vector to avoid real-time allocations.
- triggerNewGrain: Adds a new Grain object to the active grains collection with default parameters (durationInSamples = 44100).
- processBlock: Updates the state of active grains. It increments the age of each grain and marks grains as 'dead' (isAlive = false) if their age exceeds their duration. It then removes all dead grains from the collection using the erase-remove idiom.

The changes are confined to plugin/source/AudioEngine.cpp, which was created as part of this work, and relies on the Grain struct and AudioEngine class declaration in plugin/source/PointilismInterfaces.h.