### PR TITLE
I've implemented the stochastic pitch and pan logic in `StochasticMod…

### DIFF
--- a/plugin/source/PointilismInterfaces.h
+++ b/plugin/source/PointilismInterfaces.h
@@ -80,7 +80,12 @@ private:
     // Parameters controlled by the UI (using std::atomic for thread-safety)
     std::atomic<float> pitch { 60.0f };
     std::atomic<float> dispersion { 12.0f };
+    std::atomic<float> centralPan { 0.0f };
+    std::atomic<float> panSpread { 0.5f };
     // ... other atomic parameters for density, duration, etc.
+
+    std::normal_distribution<float> pitchDistribution;
+    std::normal_distribution<float> panDistribution;
 };
 
 

--- a/plugin/source/StochasticModel.cpp
+++ b/plugin/source/StochasticModel.cpp
@@ -1,0 +1,38 @@
+#include "PointilismInterfaces.h" // Required for StochasticModel definition
+#include <random> // Will be needed for other methods
+#include <algorithm> // Will be needed for std::clamp in other methods
+
+void StochasticModel::setPitchAndDispersion(float centralPitch, float dispersionAmount)
+{
+    pitch.store(centralPitch);
+    dispersion.store(dispersionAmount);
+}
+
+void StochasticModel::setPanAndSpread(float newCentralPan, float newSpreadAmount)
+{
+    centralPan.store(newCentralPan);
+    panSpread.store(newSpreadAmount);
+}
+
+void StochasticModel::generateNewGrain(Grain& newGrain)
+{
+    // Pitch
+    using PitchDistributionParams = std::normal_distribution<float>::param_type;
+    pitchDistribution.param(PitchDistributionParams(pitch.load(), dispersion.load()));
+    newGrain.pitch = pitchDistribution(randomEngine);
+
+    // Pan
+    using PanDistributionParams = std::normal_distribution<float>::param_type;
+    panDistribution.param(PanDistributionParams(centralPan.load(), panSpread.load()));
+    float generatedPan = panDistribution(randomEngine);
+    newGrain.pan = std::clamp(generatedPan, -1.0f, 1.0f);
+
+    // Other grain properties will be set elsewhere or in future tasks.
+    // For now, ensure isAlive is true and assign a temporary ID or leave as default.
+    newGrain.isAlive = true;
+    // newGrain.id = ...; // Not part of this task's core requirements for pitch/pan
+    // newGrain.amplitude = ...;
+    // newGrain.durationInSamples = ...;
+    // newGrain.ageInSamples = 0;
+    // newGrain.sourceSamplePosition = ...;
+}


### PR DESCRIPTION
…el`.

I added new atomic members for pan (`centralPan`, `panSpread`) and `std::normal_distribution` objects (`pitchDistribution`, `panDistribution`) to the `StochasticModel` class in `PointillismInterfaces.h`.

I created `StochasticModel.cpp` and implemented the following methods:
- `setPitchAndDispersion`: Stores central pitch and dispersion.
- `setPanAndSpread`: Stores central pan and spread.
- `generateNewGrain`:
    - Sets grain pitch using a normal distribution (mean=`centralPitch`, stddev=`dispersion`).
    - Sets grain pan using a normal distribution (mean=`centralPan`, stddev=`panSpread`), clamping the result to [-1.0, 1.0].

The random number generator `randomEngine` (`std::mt19937`) declared in `StochasticModel` is used by the distributions.