### PR TITLE
This commit introduces the core logic for controlling grain duration …

### DIFF
--- a/plugin/source/PointilismInterfaces.h
+++ b/plugin/source/PointilismInterfaces.h
@@ -76,10 +76,17 @@ private:
     // and various std::distribution objects (e.g., normal_distribution,
     // uniform_real_distribution, poisson_distribution) to model the parameters. 
     std::mt19937 randomEngine;
+    std::poisson_distribution<int> poissonDistribution_;
+    std::uniform_real_distribution<float> uniformRealDistribution_ { -0.5f, 0.5f };
 
     // Parameters controlled by the UI (using std::atomic for thread-safety)
     std::atomic<float> pitch { 60.0f };
     std::atomic<float> dispersion { 12.0f };
+    std::atomic<float> averageDurationMs_ { 0.0f };
+    std::atomic<float> durationVariation_ { 0.0f };
+    std::atomic<float> grainsPerSecond_ { 10.0f };
+    std::atomic<TemporalDistribution> temporalDistributionModel_ { TemporalDistribution::Uniform };
+    std::atomic<double> sampleRate_ { 44100.0 };
     // ... other atomic parameters for density, duration, etc.
 };
 

--- a/plugin/source/StochasticModel.cpp
+++ b/plugin/source/StochasticModel.cpp
@@ -1,0 +1,110 @@
+#include "PointilismInterfaces.h" // Assuming this is the correct path relative to the cpp file
+#include <random> // For distributions if needed directly in setters, though likely just for storage here
+#include <cmath>  // For std::abs, std::max etc. if needed
+#include <limits> // For std::numeric_limits<double>::epsilon(), INT_MAX
+
+// Forward declaration or ensure StochasticModel is fully defined via header
+// class StochasticModel; // Not needed if PointilismInterfaces.h includes full definition
+
+void StochasticModel::setDurationAndVariation(float averageDurationMs, float variation)
+{
+    averageDurationMs_ = averageDurationMs;
+    durationVariation_ = variation;
+}
+
+void StochasticModel::setDensity(float grainsPerSecond)
+{
+    grainsPerSecond_ = grainsPerSecond;
+}
+
+void StochasticModel::setTemporalDistribution(StochasticModel::TemporalDistribution model)
+{
+    temporalDistributionModel_ = model;
+}
+
+void StochasticModel::setSampleRate(double newSampleRate)
+{
+    sampleRate_ = newSampleRate;
+}
+
+void StochasticModel::generateNewGrain(Grain& newGrain)
+{
+    // 1. Get atomic values
+    float avgDurationMs = averageDurationMs_.load(std::memory_order_relaxed);
+    float variation = durationVariation_.load(std::memory_order_relaxed); // This is the 'variation' parameter, e.g., 0.1 for 10%
+    double currentSampleRate = sampleRate_.load(std::memory_order_relaxed);
+
+    // 2. Calculate randomized duration factor
+    // uniformRealDistribution_ is [-0.5f, 0.5f].
+    // randomPercentDeviation will be in range [-variation, +variation]
+    // e.g. if variation = 0.1, then randomPercentDeviation is in [-0.1, 0.1]
+    float randomPercentDeviation = uniformRealDistribution_(randomEngine) * 2.0f * variation;
+
+    // 3. Randomized duration in ms
+    float randomizedDurationMs = avgDurationMs * (1.0f + randomPercentDeviation);
+
+    // 4. Ensure duration is not negative
+    randomizedDurationMs = std::max(0.0f, randomizedDurationMs);
+
+    // 5. Convert to samples
+    // Ensure sampleRate is not zero to prevent division by zero or NaN issues.
+    if (currentSampleRate <= 0) {
+        // Fallback to a default sample rate, or log an error.
+        // For now, using a common default.
+        currentSampleRate = 44100.0;
+    }
+    newGrain.durationInSamples = static_cast<int>((randomizedDurationMs / 1000.0) * currentSampleRate);
+
+    // Other members of Grain (pitch, pan, amplitude, etc.) are not set here
+    // as per the current task. They would be set by other parts of StochasticModel
+    // or have default values.
+}
+
+int StochasticModel::getSamplesUntilNextEvent()
+{
+    // 1. Get atomic values
+    float currentGrainsPerSecond = grainsPerSecond_.load(std::memory_order_relaxed);
+    double currentSampleRate = sampleRate_.load(std::memory_order_relaxed);
+    TemporalDistribution currentModel = temporalDistributionModel_.load(std::memory_order_relaxed);
+
+    // 2. Validate inputs and calculate average samples per grain
+    if (currentGrainsPerSecond <= 0.0f || currentSampleRate <= 0.0)
+    {
+        // Cannot compute a meaningful event interval, return a very large number of samples
+        // to effectively pause event generation.
+        return INT_MAX;
+    }
+
+    double averageSamplesPerGrain = currentSampleRate / currentGrainsPerSecond;
+
+    // Check for potential issues with averageSamplesPerGrain before using it,
+    // especially with the Poisson distribution.
+    if (averageSamplesPerGrain <= 0.0 || std::isinf(averageSamplesPerGrain) || std::isnan(averageSamplesPerGrain)) {
+        return INT_MAX; // Not a valid mean for Poisson or for timing.
+    }
+
+
+    // 3. Handle TemporalDistribution models
+    if (currentModel == TemporalDistribution::Uniform)
+    {
+        return static_cast<int>(averageSamplesPerGrain);
+    }
+    else if (currentModel == TemporalDistribution::Poisson)
+    {
+        // Ensure the mean for the Poisson distribution is positive.
+        // Clamping to a very small positive number if averageSamplesPerGrain is too small,
+        // as Poisson distribution mean must be > 0.
+        double poissonMean = std::max(std::numeric_limits<double>::epsilon(), averageSamplesPerGrain);
+
+        // Update the Poisson distribution's mean parameter.
+        // This is technically not thread-safe if multiple threads call this concurrently
+        // AND randomEngine is shared without locks. However, randomEngine itself is not thread-safe by default.
+        // Assuming single audio thread access for generation, or external synchronization for randomEngine if shared.
+        // For typical JUCE audio processing, this method and generateNewGrain would be called from the same audio thread.
+        poissonDistribution_.param(std::poisson_distribution<int>::param_type(poissonMean));
+        return poissonDistribution_(randomEngine);
+    }
+
+    // Fallback, though ideally all enum values should be handled.
+    return INT_MAX;
+}


### PR DESCRIPTION
…and rhythmic timing within the StochasticModel class.

Key changes:

- Added atomic member variables to `StochasticModel` in `PointillismInterfaces.h` to store parameters for:
    - Average grain duration (ms) and its variation percentage.
    - Grain density (grains per second).
    - Temporal distribution model (Uniform, Poisson).
    - Sample rate.
- Added `std::poisson_distribution` and `std::uniform_real_distribution` as private members for random number generation.
- Created `StochasticModel.cpp` and implemented the following methods:
    - `setDurationAndVariation()`: Stores duration and variation parameters.
    - `setDensity()`: Stores grains per second.
    - `setTemporalDistribution()`: Sets the distribution model (Uniform/Poisson).
    - `setSampleRate()`: Stores the audio sample rate.
    - `generateNewGrain()`:
        - Calculates the duration for a new grain.
        - Randomizes the average duration based on the variation amount. - Converts the duration from milliseconds to samples using the sample rate. - Sets the `durationInSamples` member of the `Grain` struct.
    - `getSamplesUntilNextEvent()`: - Calculates the average number of samples per grain from density and sample rate. - Returns the average directly if the `TemporalDistribution` is Uniform. - Returns a Poisson-distributed random delay if the model is Poisson, using `std::poisson_distribution` initialized with the calculated average.

Input validation and safety checks (e.g., for division by zero, valid distribution parameters) have been included in the implementations.