### PR TITLE
Add DebugUIPanel for StochasticModel runtime control

### DIFF
--- a/plugin/include/Pointilsynth/PluginEditor.h
+++ b/plugin/include/Pointilsynth/PluginEditor.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include "PluginProcessor.h"
+#include "../../source/DebugUIPanel.h"       // Added for DebugUIPanel
+// PointilismInterfaces.h is included by PluginProcessor.h, which is included above.
+// If direct use of StochasticModel type was needed here, an include would be good:
+// #include "../../source/PointilismInterfaces.h"
 
 namespace audio_plugin {
 
@@ -16,6 +20,8 @@ private:
   // This reference is provided as a quick way for your editor to
   // access the processor object that created it.
   AudioPluginAudioProcessor& processorRef;
+
+  DebugUIPanel debugUIPanel; // Added DebugUIPanel member
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessorEditor)
 };

--- a/plugin/include/Pointilsynth/PluginProcessor.h
+++ b/plugin/include/Pointilsynth/PluginProcessor.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <juce_audio_processors/juce_audio_processors.h>
+#include "../../source/PointilismInterfaces.h" // Added for AudioEngine and StochasticModel
 
 namespace audio_plugin {
 class AudioPluginAudioProcessor : public juce::AudioProcessor {
 public:
   AudioPluginAudioProcessor();
+  // Provide access to the StochasticModel for the editor
+  StochasticModel* getStochasticModel() { return audioEngine.getStochasticModel(); }
   ~AudioPluginAudioProcessor() override;
 
   void prepareToPlay(double sampleRate, int samplesPerBlock) override;
@@ -36,6 +39,8 @@ public:
   void setStateInformation(const void* data, int sizeInBytes) override;
 
 private:
+  AudioEngine audioEngine; // Added AudioEngine member
+
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)
 };
 }  // namespace audio_plugin

--- a/plugin/source/AudioEngine.cpp
+++ b/plugin/source/AudioEngine.cpp
@@ -16,9 +16,11 @@
 //     // ... other members
 // };
 
-void AudioEngine::prepareToPlay(double /*sampleRate*/, int /*samplesPerBlock*/)
+void AudioEngine::prepareToPlay(double sampleRate, int /*samplesPerBlock*/) // Uncommented sampleRate
 {
-    grains.reserve(1024);
+    currentSampleRate = sampleRate; // Store sampleRate
+    stochasticModel.setSampleRate(sampleRate); // Inform StochasticModel
+    grains.reserve(1024); // Existing logic
 }
 
 // Add the following method:
@@ -55,8 +57,9 @@ void AudioEngine::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffe
         }),
         grains.end()
     );
+} // End of processBlock
 
-// Implementation of loadAudioSample
+// Implementation of loadAudioSample - MOVED OUTSIDE processBlock
 void AudioEngine::loadAudioSample(const juce::File& audioFile)
 {
     juce::AudioFormatManager formatManager;

--- a/plugin/source/DebugUIPanel.cpp
+++ b/plugin/source/DebugUIPanel.cpp
@@ -1,0 +1,202 @@
+#include "DebugUIPanel.h"
+#include "PointilismInterfaces.h" // For StochasticModel::TemporalDistribution
+
+// Constructor
+DebugUIPanel::DebugUIPanel(StochasticModel* model) : stochasticModel(model)
+{
+    // Initialize and configure sliders and labels
+    // Pitch
+    addAndMakeVisible(pitchSlider);
+    pitchSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+    pitchSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+    pitchSlider.setRange(20.0, 100.0, 0.1); // MIDI note numbers
+    if (stochasticModel) pitchSlider.setValue(stochasticModel->getPitch(), juce::dontSendNotification);
+    pitchSlider.onValueChange = [this] { pitchSliderChanged(); };
+    addAndMakeVisible(pitchLabel);
+    pitchLabel.setText("Pitch", juce::dontSendNotification);
+    pitchLabel.attachToComponent(&pitchSlider, true); // true for onLeft
+
+    // Dispersion
+    addAndMakeVisible(dispersionSlider);
+    dispersionSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+    dispersionSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+    dispersionSlider.setRange(0.0, 24.0, 0.1); // Semitones
+    if (stochasticModel) dispersionSlider.setValue(stochasticModel->getDispersion(), juce::dontSendNotification);
+    dispersionSlider.onValueChange = [this] { dispersionSliderChanged(); };
+    addAndMakeVisible(dispersionLabel);
+    dispersionLabel.setText("Dispersion", juce::dontSendNotification);
+    dispersionLabel.attachToComponent(&dispersionSlider, true);
+
+    // Duration
+    addAndMakeVisible(durationSlider);
+    durationSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+    durationSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+    durationSlider.setRange(10.0, 1000.0, 1.0); // Milliseconds
+    if (stochasticModel) durationSlider.setValue(stochasticModel->getAverageDurationMs(), juce::dontSendNotification);
+    durationSlider.onValueChange = [this] { durationSliderChanged(); };
+    addAndMakeVisible(durationLabel);
+    durationLabel.setText("Duration (ms)", juce::dontSendNotification);
+    durationLabel.attachToComponent(&durationSlider, true);
+
+    // Duration Variation
+    addAndMakeVisible(durationVariationSlider);
+    durationVariationSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+    durationVariationSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+    durationVariationSlider.setRange(0.0, 1.0, 0.01); // Percentage
+    if (stochasticModel) durationVariationSlider.setValue(stochasticModel->getDurationVariation(), juce::dontSendNotification);
+    durationVariationSlider.onValueChange = [this] { durationVariationSliderChanged(); };
+    addAndMakeVisible(durationVariationLabel);
+    durationVariationLabel.setText("Duration Var.", juce::dontSendNotification);
+    durationVariationLabel.attachToComponent(&durationVariationSlider, true);
+
+    // Pan
+    addAndMakeVisible(panSlider);
+    panSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+    panSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+    panSlider.setRange(-1.0, 1.0, 0.01); // -1 (L) to 1 (R)
+    if (stochasticModel) panSlider.setValue(stochasticModel->getCentralPan(), juce::dontSendNotification);
+    panSlider.onValueChange = [this] { panSliderChanged(); };
+    addAndMakeVisible(panLabel);
+    panLabel.setText("Pan", juce::dontSendNotification);
+    panLabel.attachToComponent(&panSlider, true);
+
+    // Pan Spread
+    addAndMakeVisible(panSpreadSlider);
+    panSpreadSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+    panSpreadSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+    panSpreadSlider.setRange(0.0, 1.0, 0.01); // Spread amount
+    if (stochasticModel) panSpreadSlider.setValue(stochasticModel->getPanSpread(), juce::dontSendNotification);
+    panSpreadSlider.onValueChange = [this] { panSpreadSliderChanged(); };
+    addAndMakeVisible(panSpreadLabel);
+    panSpreadLabel.setText("Pan Spread", juce::dontSendNotification);
+    panSpreadLabel.attachToComponent(&panSpreadSlider, true);
+
+    // Density
+    addAndMakeVisible(densitySlider);
+    densitySlider.setSliderStyle(juce::Slider::LinearHorizontal);
+    densitySlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+    densitySlider.setRange(0.1, 50.0, 0.1); // Grains per second
+    if (stochasticModel) densitySlider.setValue(stochasticModel->getGrainsPerSecond(), juce::dontSendNotification);
+    densitySlider.onValueChange = [this] { densitySliderChanged(); };
+    addAndMakeVisible(densityLabel);
+    densityLabel.setText("Density (gr/s)", juce::dontSendNotification);
+    densityLabel.attachToComponent(&densitySlider, true);
+
+    // Temporal Distribution
+    addAndMakeVisible(temporalDistributionComboBox);
+    temporalDistributionComboBox.addItem("Uniform", static_cast<int>(StochasticModel::TemporalDistribution::Uniform) + 1);
+    temporalDistributionComboBox.addItem("Poisson", static_cast<int>(StochasticModel::TemporalDistribution::Poisson) + 1);
+    if (stochasticModel) temporalDistributionComboBox.setSelectedId(static_cast<int>(stochasticModel->getTemporalDistributionModel()) + 1, juce::dontSendNotification);
+    temporalDistributionComboBox.onChange = [this] { temporalDistributionChanged(); };
+    addAndMakeVisible(temporalDistributionLabel);
+    temporalDistributionLabel.setText("Distribution", juce::dontSendNotification);
+    temporalDistributionLabel.attachToComponent(&temporalDistributionComboBox, true);
+
+    // The editor is responsible for setting our size.
+    // setSize(600, 400); // This was set by PluginEditor
+}
+
+DebugUIPanel::~DebugUIPanel()
+{
+    // Destructor (JUCE handles cleanup of child components as they are owned)
+    // Listeners are lambda based and managed by JUCE Slider/ComboBox, no manual removal needed.
+}
+
+void DebugUIPanel::paint(juce::Graphics& g)
+{
+    // Fill the background
+    g.fillAll(getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
+}
+
+void DebugUIPanel::resized()
+{
+    juce::FlexBox fb;
+    fb.flexDirection = juce::FlexBox::Direction::column;
+    fb.alignItems = juce::FlexBox::AlignItems::stretch; // Components will stretch to width
+    fb.justifyContent = juce::FlexBox::JustifyContent::flexStart;
+
+    // Helper to add item with margin and fixed height
+    auto addItemToFlexBox = [&](juce::Component& comp, float height) {
+        // Labels are attached to the left, so they don't need separate FlexItems if they size themselves.
+        // The component itself (slider/combobox) takes the full width.
+        fb.items.add(juce::FlexItem(comp).withHeight(height).withMargin(juce::FlexItem::Margin(2.0f, 0, 2.0f, 0))); // Top/Bottom margin
+    };
+
+    float standardItemHeight = 25.0f; // Standard height for sliders and combobox
+
+    // Labels are attached to the left of these components.
+    // Their width is set by label.attachToComponent or can be set explicitly if needed.
+    // For attached labels, their width is managed by JUCE.
+    // We can set a common width for labels if desired:
+    // pitchLabel.setMinimumHorizontalScale(0.8f); // Example
+    // Or ensure labels have enough text space.
+    // For attached labels, their width is part of the component they are attached to.
+    // The FlexBox will lay out the main components (sliders, combobox).
+
+    addItemToFlexBox(pitchSlider, standardItemHeight);
+    addItemToFlexBox(dispersionSlider, standardItemHeight);
+    addItemToFlexBox(durationSlider, standardItemHeight);
+    addItemToFlexBox(durationVariationSlider, standardItemHeight);
+    addItemToFlexBox(panSlider, standardItemHeight);
+    addItemToFlexBox(panSpreadSlider, standardItemHeight);
+    addItemToFlexBox(densitySlider, standardItemHeight);
+    addItemToFlexBox(temporalDistributionComboBox, standardItemHeight);
+
+    // Perform layout within the panel's bounds, reduced by a margin for aesthetics
+    fb.performLayout(getLocalBounds().reduced(10));
+}
+
+// Callback methods
+void DebugUIPanel::pitchSliderChanged()
+{
+    if (stochasticModel)
+        stochasticModel->setPitchAndDispersion(pitchSlider.getValue(), dispersionSlider.getValue());
+}
+
+void DebugUIPanel::dispersionSliderChanged()
+{
+    if (stochasticModel)
+        stochasticModel->setPitchAndDispersion(pitchSlider.getValue(), dispersionSlider.getValue());
+}
+
+void DebugUIPanel::durationSliderChanged()
+{
+    if (stochasticModel)
+        stochasticModel->setDurationAndVariation(durationSlider.getValue(), durationVariationSlider.getValue());
+}
+
+void DebugUIPanel::durationVariationSliderChanged()
+{
+    if (stochasticModel)
+        stochasticModel->setDurationAndVariation(durationSlider.getValue(), durationVariationSlider.getValue());
+}
+
+void DebugUIPanel::panSliderChanged()
+{
+    if (stochasticModel)
+        stochasticModel->setPanAndSpread(panSlider.getValue(), panSpreadSlider.getValue());
+}
+
+void DebugUIPanel::panSpreadSliderChanged()
+{
+    if (stochasticModel)
+        stochasticModel->setPanAndSpread(panSlider.getValue(), panSpreadSlider.getValue());
+}
+
+void DebugUIPanel::densitySliderChanged()
+{
+    if (stochasticModel)
+        stochasticModel->setDensity(densitySlider.getValue());
+}
+
+void DebugUIPanel::temporalDistributionChanged()
+{
+    if (stochasticModel)
+    {
+        int selectedId = temporalDistributionComboBox.getSelectedId();
+        // Enum values are 0-indexed, ComboBox IDs are 1-indexed
+        if (selectedId > 0) {
+             stochasticModel->setTemporalDistribution(static_cast<StochasticModel::TemporalDistribution>(selectedId - 1));
+        }
+    }
+}

--- a/plugin/source/DebugUIPanel.h
+++ b/plugin/source/DebugUIPanel.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "PointilismInterfaces.h" // Assuming this is the correct path
+
+class DebugUIPanel : public juce::Component
+{
+public:
+    // Constructor that takes a pointer to the StochasticModel
+    DebugUIPanel(StochasticModel* model);
+    ~DebugUIPanel() override;
+
+    // juce::Component overrides
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+
+private:
+    // Pointer to the audio engine's stochastic model
+    StochasticModel* stochasticModel;
+
+    // UI Components
+    juce::Slider pitchSlider;
+    juce::Label pitchLabel;
+    juce::Slider dispersionSlider;
+    juce::Label dispersionLabel;
+
+    juce::Slider durationSlider;
+    juce::Label durationLabel;
+    juce::Slider durationVariationSlider;
+    juce::Label durationVariationLabel;
+
+    juce::Slider panSlider;
+    juce::Label panLabel;
+    juce::Slider panSpreadSlider;
+    juce::Label panSpreadLabel;
+
+    juce::Slider densitySlider;
+    juce::Label densityLabel;
+
+    juce::ComboBox temporalDistributionComboBox;
+    juce::Label temporalDistributionLabel;
+
+    // Callback methods for UI components
+    void pitchSliderChanged();
+    void dispersionSliderChanged();
+    void durationSliderChanged();
+    void durationVariationSliderChanged();
+    void panSliderChanged();
+    void panSpreadSliderChanged();
+    void densitySliderChanged();
+    void temporalDistributionChanged();
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DebugUIPanel)
+};

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -1,14 +1,17 @@
-#include "YourPluginName/PluginEditor.h"
-#include "YourPluginName/PluginProcessor.h"
+#include "Pointilsynth/PluginEditor.h"
+#include "Pointilsynth/PluginProcessor.h"
 
 namespace audio_plugin {
 AudioPluginAudioProcessorEditor::AudioPluginAudioProcessorEditor(
     AudioPluginAudioProcessor& p)
-    : AudioProcessorEditor(&p), processorRef(p) {
+    : AudioProcessorEditor(&p), processorRef(p), debugUIPanel(processorRef.getStochasticModel()) { // Initialize debugUIPanel
   juce::ignoreUnused(processorRef);
+
+  addAndMakeVisible(debugUIPanel); // Add and make panel visible
+
   // Make sure that before the constructor has finished, you've set the
   // editor's size to whatever you need it to be.
-  setSize(400, 300);
+  setSize(600, 400); // Set size for DebugUIPanel
 }
 
 AudioPluginAudioProcessorEditor::~AudioPluginAudioProcessorEditor() {}
@@ -19,14 +22,15 @@ void AudioPluginAudioProcessorEditor::paint(juce::Graphics& g) {
   g.fillAll(
       getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
 
-  g.setColour(juce::Colours::white);
-  g.setFont(15.0f);
-  g.drawFittedText("Hello World!", getLocalBounds(),
-                   juce::Justification::centred, 1);
+  // g.setColour(juce::Colours::white); // Hello World text removed
+  // g.setFont(15.0f);
+  // g.drawFittedText("Hello World!", getLocalBounds(),
+  //                  juce::Justification::centred, 1);
 }
 
 void AudioPluginAudioProcessorEditor::resized() {
   // This is generally where you'll want to lay out the positions of any
   // subcomponents in your editor..
+  debugUIPanel.setBounds(getLocalBounds()); // Make DebugUIPanel fill the editor
 }
 }  // namespace audio_plugin

--- a/plugin/source/PluginProcessor.cpp
+++ b/plugin/source/PluginProcessor.cpp
@@ -1,5 +1,5 @@
-#include "YourPluginName/PluginProcessor.h"
-#include "YourPluginName/PluginEditor.h"
+#include "Pointilsynth/PluginProcessor.h"
+#include "Pointilsynth/PluginEditor.h"
 
 namespace audio_plugin {
 AudioPluginAudioProcessor::AudioPluginAudioProcessor()
@@ -76,12 +76,14 @@ void AudioPluginAudioProcessor::prepareToPlay(double sampleRate,
                                               int samplesPerBlock) {
   // Use this method as the place to do any pre-playback
   // initialisation that you need..
-  juce::ignoreUnused(sampleRate, samplesPerBlock);
+  // juce::ignoreUnused(sampleRate, samplesPerBlock); // Removed by audioEngine call
+  audioEngine.prepareToPlay(sampleRate, samplesPerBlock);
 }
 
 void AudioPluginAudioProcessor::releaseResources() {
   // When playback stops, you can use this as an opportunity to free up any
   // spare memory, etc.
+  // audioEngine.releaseResources(); // If AudioEngine had such a method
 }
 
 bool AudioPluginAudioProcessor::isBusesLayoutSupported(
@@ -131,11 +133,12 @@ void AudioPluginAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer,
   // the samples and the outer loop is handling the channels.
   // Alternatively, you can process the samples with the channels
   // interleaved by keeping the same state.
-  for (int channel = 0; channel < totalNumInputChannels; ++channel) {
-    auto* channelData = buffer.getWritePointer(channel);
-    juce::ignoreUnused(channelData);
-    // ..do something to the data...
-  }
+  // for (int channel = 0; channel < totalNumInputChannels; ++channel) { // Removed by audioEngine call
+  //   auto* channelData = buffer.getWritePointer(channel);
+  //   juce::ignoreUnused(channelData);
+  //   // ..do something to the data...
+  // }
+  audioEngine.processBlock(buffer, midiMessages);
 }
 
 bool AudioPluginAudioProcessor::hasEditor() const {

--- a/plugin/source/PointilismInterfaces.h
+++ b/plugin/source/PointilismInterfaces.h
@@ -55,11 +55,50 @@ public:
     //==============================================================================
     // Parameter Setters (called by the UI thread)
     //==============================================================================
-    void setPitchAndDispersion(float centralPitch, float dispersion) { /* ... */ }  // 
-    void setDurationAndVariation(float averageDurationMs, float variation) { /* ... */ } // 
-    void setPanAndSpread(float centralPan, float spread) { /* ... */ } // 
-    void setDensity(float grainsPerSecond) { /* ... */ } // 
-    void setTemporalDistribution(TemporalDistribution model) { /* ... */ } // 
+    void setPitchAndDispersion(float centralPitchValue, float dispersionValue) {
+        pitch.store(centralPitchValue);
+        dispersion.store(dispersionValue);
+        pitchDistribution = std::normal_distribution<float>(centralPitchValue, dispersionValue);
+    }
+    void setDurationAndVariation(float averageDurationMsValue, float variationValue) {
+        averageDurationMs_.store(averageDurationMsValue);
+        durationVariation_.store(variationValue);
+        // Assuming variationValue is a multiplier for stddev: e.g. 0.1 for 10%
+        // Ensure stddev is not negative if variationValue can be large.
+        float stdDev = averageDurationMsValue * variationValue;
+        durationDistribution = std::normal_distribution<float>(averageDurationMsValue, stdDev > 0 ? stdDev : 0.001f);
+    }
+    void setPanAndSpread(float centralPanValue, float spreadValue) {
+        centralPan.store(centralPanValue);
+        panSpread.store(spreadValue);
+        panDistribution = std::normal_distribution<float>(centralPanValue, spreadValue);
+    }
+    void setDensity(float grainsPerSecondValue) { // Already correctly implemented from previous turn
+        grainsPerSecond_.store(grainsPerSecondValue);
+        // If Poisson distribution rate depends on this, update here.
+        // e.g., if using grainsPerSecond directly for poisson lambda:
+        // poissonDistribution_ = std::poisson_distribution<int>(grainsPerSecondValue);
+        // More likely, it's related to sampleRate: events_per_sample = grainsPerSecond / sampleRate
+        // And then lambda = events_per_sample * block_size for poisson events per block.
+        // This logic is typically in getSamplesUntilNextEvent() or similar.
+    }
+    void setTemporalDistribution(TemporalDistribution modelValue) { // Already correctly implemented
+        temporalDistributionModel_.store(modelValue);
+    }
+
+    //==============================================================================
+    // Parameter Getters (called by UI thread via DebugUIPanel)
+    //==============================================================================
+    float getPitch() const { return pitch.load(); }
+    float getDispersion() const { return dispersion.load(); }
+    float getAverageDurationMs() const { return averageDurationMs_.load(); }
+    float getDurationVariation() const { return durationVariation_.load(); }
+    float getCentralPan() const { return centralPan.load(); }
+    float getPanSpread() const { return panSpread.load(); }
+    float getGrainsPerSecond() const { return grainsPerSecond_.load(); }
+    TemporalDistribution getTemporalDistributionModel() const { return temporalDistributionModel_.load(); }
+    double getSampleRate() const { return sampleRate_.load(); }
+
 
     //==============================================================================
     // Value Generators (called by the AudioEngine thread)
@@ -74,25 +113,42 @@ public:
 private:
     // Private members would include std::mt19937 for random number generation,
     // and various std::distribution objects (e.g., normal_distribution,
-    // uniform_real_distribution, poisson_distribution) to model the parameters. 
-    std::mt19937 randomEngine;
-    std::poisson_distribution<int> poissonDistribution_;
+    // uniform_real_distribution, poisson_distribution) to model the parameters.
+    // Ensure randomEngine is seeded, e.g., in constructor or a dedicated init method.
+    std::mt19937 randomEngine { std::random_device{}() }; // Example seeding
+    std::poisson_distribution<int> poissonDistribution_ {10.0}; // Example initialization
     std::uniform_real_distribution<float> uniformRealDistribution_ { -0.5f, 0.5f };
 
     // Parameters controlled by the UI (using std::atomic for thread-safety)
     std::atomic<float> pitch { 60.0f };
-    std::atomic<float> dispersion { 12.0f };
-    std::atomic<float> averageDurationMs_ { 0.0f };
-    std::atomic<float> durationVariation_ { 0.0f };
+    std::atomic<float> dispersion { 12.0f }; // e.g. in semitones
+    std::atomic<float> averageDurationMs_ { 200.0f }; // e.g. in milliseconds
+    std::atomic<float> durationVariation_ { 0.25f }; // e.g. 25% variation
     std::atomic<float> grainsPerSecond_ { 10.0f };
     std::atomic<TemporalDistribution> temporalDistributionModel_ { TemporalDistribution::Uniform };
-    std::atomic<double> sampleRate_ { 44100.0 };
-    std::atomic<float> centralPan { 0.0f };
-    std::atomic<float> panSpread { 0.5f };
+    std::atomic<double> sampleRate_ { 44100.0 }; // Should be set by prepareToPlay in AudioEngine
+    std::atomic<float> centralPan { 0.0f }; // -1 (L) to 1 (R)
+    std::atomic<float> panSpread { 0.5f }; // 0 (no spread) to 1 (full spread)
 
 
-    std::normal_distribution<float> pitchDistribution;
-    std::normal_distribution<float> panDistribution;
+    // Distributions - these should be updated when parameters change.
+    // For simplicity, the setters currently just store values. A more complete
+    // implementation would update these distributions in the setters.
+    std::normal_distribution<float> pitchDistribution { pitch.load(), dispersion.load() };
+    std::normal_distribution<float> panDistribution { centralPan.load(), panSpread.load() };
+    // Duration distribution might be normal or log-normal depending on desired behavior
+    std::normal_distribution<float> durationDistribution { averageDurationMs_.load(), averageDurationMs_.load() * durationVariation_.load() };
+
+public: // Public setter for sample rate, to be called by AudioEngine
+    void setSampleRate(double sr) {
+        sampleRate_.store(sr);
+        // Update any distributions or parameters that depend on the sample rate.
+        // For example, if poissonDistribution_ is for events per second:
+        // poissonDistribution_ = std::poisson_distribution<double>(grainsPerSecond_.load());
+        // And then getSamplesUntilNextEvent translates this to samples.
+        // Or if it's events per block (more complex here).
+        // For now, just storing it. The getSamplesUntilNextEvent() will need to use sampleRate_ correctly.
+    }
 };
 
 


### PR DESCRIPTION
This commit introduces a new JUCE component, DebugUIPanel, to provide an internal UI for real-time control over the StochasticModel's parameters.

Key changes:
- Created DebugUIPanel.h and DebugUIPanel.cpp under plugin/source/.
- DebugUIPanel provides sliders for pitch, dispersion, duration, duration variation, pan, pan spread, and density.
- A ComboBox is included for selecting the temporal distribution model (Uniform/Poisson).
- UI elements are linked to StochasticModel's setter methods, and their initial states are populated using getter methods.
- StochasticModel in PointilismInterfaces.h has been updated with:
    - Getter methods for all controllable parameters.
    - Implementation of previously declared setter methods.
    - A new setSampleRate(double sr) method.
- AudioEngine::prepareToPlay in AudioEngine.cpp now calls stochasticModel.setSampleRate() to ensure correct sample rate propagation.
- Corrected a structural issue in AudioEngine.cpp where loadAudioSample was nested incorrectly.
- Integrated DebugUIPanel into the PluginEditor, making it visible and functional within the plugin.

This UI panel is intended for debugging and testing purposes, allowing you to dynamically adjust sound engine parameters.