### PR TITLE
Implement preset saving and loading for StochasticModel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,18 @@ cpmaddpackage(
   "gtest_force_shared_crt ON"
 )
 
+cpmaddpackage(
+  NAME
+  nlohmann_json
+  VERSION
+  3.11.3
+  GITHUB_REPOSITORY
+  nlohmann/json
+  OPTIONS
+  "JSON_BuildTests OFF"
+  "JSON_Install OFF"
+)
+
 # Add compiler warning utilities
 include(cmake/CompilerWarnings.cmake)
 include(cmake/Util.cmake)

--- a/Source/Data/PresetManager.cpp
+++ b/Source/Data/PresetManager.cpp
@@ -1,0 +1,136 @@
+#include "PresetManager.h"
+#include "juce_core/juce_core.h"    // For juce::File, juce::FileInputStream, juce::FileOutputStream
+#include "nlohmann/json.hpp"        // For nlohmann::json
+#include <fstream>                  // For std::ofstream, std::ifstream
+
+namespace Pointilism
+{
+
+PresetManager::PresetManager(StochasticModel& model)
+    : model_(model)
+{
+}
+
+bool PresetManager::savePreset(const juce::File& fileToSave)
+{
+    nlohmann::json presetJson;
+
+    // --- Global Parameters ---
+    presetJson["global"]["density"] = model_.getGlobalDensity();
+    presetJson["global"]["minDistance"] = model_.getGlobalMinDistance();
+    presetJson["global"]["pitchOffset"] = model_.getGlobalPitchOffset();
+    presetJson["global"]["panOffset"] = model_.getGlobalPanOffset();
+    presetJson["global"]["velocityOffset"] = model_.getGlobalVelocityOffset();
+    presetJson["global"]["durationOffset"] = model_.getGlobalDurationOffset();
+    presetJson["global"]["temporalDistribution"] = static_cast<int>(model_.getGlobalTemporalDistribution());
+    presetJson["global"]["tempoSync"] = model_.isGlobalTempoSyncEnabled();
+    presetJson["global"]["numVoices"] = model_.getGlobalNumVoices();
+    presetJson["global"]["numGrains"] = model_.getGlobalNumGrains();
+
+    // --- Stochastic Models (Per Voice) ---
+    // Assuming StochasticModel has methods to get these parameters for each voice.
+    // This part needs to be adapted based on how StochasticModel stores per-voice data.
+    // For simplicity, let's assume there's a fixed number of voices or a way to iterate them.
+    // This is a placeholder and needs to match the actual StochasticModel interface.
+    // For now, we'll save only the global parameters as a starting point.
+
+    // Example for saving per-voice data if model_ had such a structure:
+    /*
+    for (int i = 0; i < model_.getNumVoices(); ++i) // Assuming model_.getNumVoices() exists
+    {
+        presetJson["voices"][i]["density"] = model_.getDensity(i); // Assuming getDensity(voiceIndex)
+        presetJson["voices"][i]["minDistance"] = model_.getMinDistance(i);
+        // ... and so on for other per-voice parameters
+    }
+    */
+
+    // Use juce::FileOutputStream to write the JSON data
+    juce::FileOutputStream outputStream(fileToSave);
+
+    if (!outputStream.openedOk())
+    {
+        //DBG("Failed to open file for writing: " + fileToSave.getFullPathName());
+        return false;
+    }
+
+    // Get the JSON data as a string
+    std::string jsonString = presetJson.dump(4); // 4 spaces for indentation
+
+    // Write the string to the file
+    outputStream.write(jsonString.c_str(), jsonString.length());
+
+    return true;
+}
+
+bool PresetManager::loadPreset(const juce::File& fileToLoad)
+{
+    juce::FileInputStream inputStream(fileToLoad);
+
+    if (!inputStream.openedOk())
+    {
+        //DBG("Failed to open file for reading: " + fileToLoad.getFullPathName());
+        return false;
+    }
+
+    try
+    {
+        // Read the entire file into a string
+        juce::String fileText = inputStream.readEntireStreamAsString();
+
+        // Parse the JSON string
+        nlohmann::json presetJson = nlohmann::json::parse(fileText.toStdString());
+
+        // --- Global Parameters ---
+        if (presetJson.contains("global"))
+        {
+            auto& globalParams = presetJson["global"];
+            if (globalParams.contains("density")) model_.setGlobalDensity(globalParams["density"].get<float>());
+            if (globalParams.contains("minDistance")) model_.setGlobalMinDistance(globalParams["minDistance"].get<float>());
+            if (globalParams.contains("pitchOffset")) model_.setGlobalPitchOffset(globalParams["pitchOffset"].get<int>());
+            if (globalParams.contains("panOffset")) model_.setGlobalPanOffset(globalParams["panOffset"].get<float>());
+            if (globalParams.contains("velocityOffset")) model_.setGlobalVelocityOffset(globalParams["velocityOffset"].get<float>());
+            if (globalParams.contains("durationOffset")) model_.setGlobalDurationOffset(globalParams["durationOffset"].get<float>());
+            if (globalParams.contains("temporalDistribution")) model_.setGlobalTemporalDistribution(static_cast<StochasticModel::TemporalDistribution>(globalParams["temporalDistribution"].get<int>()));
+            if (globalParams.contains("tempoSync")) model_.setGlobalTempoSyncEnabled(globalParams["tempoSync"].get<bool>());
+            if (globalParams.contains("numVoices")) model_.setGlobalNumVoices(globalParams["numVoices"].get<int>());
+            if (globalParams.contains("numGrains")) model_.setGlobalNumGrains(globalParams["numGrains"].get<int>());
+        }
+
+        // --- Stochastic Models (Per Voice) ---
+        // Similar to saving, this needs to be adapted based on StochasticModel's structure.
+        // This is a placeholder.
+        /*
+        if (presetJson.contains("voices"))
+        {
+            const auto& voicesJson = presetJson["voices"];
+            for (unsigned i = 0; i < voicesJson.size(); ++i)
+            {
+                if (i >= static_cast<unsigned>(model_.getNumVoices())) break; // Bounds check
+
+                const auto& voiceParams = voicesJson[i];
+                if (voiceParams.contains("density")) model_.setDensity(i, voiceParams["density"].get<float>());
+                // ... and so on
+            }
+        }
+        */
+    }
+    catch (const nlohmann::json::parse_error& e)
+    {
+        //DBG("JSON parsing error: " + juce::String(e.what()));
+        return false;
+    }
+    catch (const nlohmann::json::type_error& e)
+    {
+        //DBG("JSON type error: " + juce::String(e.what()));
+        return false;
+    }
+    catch (...)
+    {
+        //DBG("Unknown error loading preset");
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace Pointilism

--- a/Source/Data/PresetManager.h
+++ b/Source/Data/PresetManager.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "juce_core/juce_core.h" // For juce::File
+#include "nlohmann/json.hpp"     // For nlohmann::json
+#include "../../plugin/source/PointilismInterfaces.h" // For StochasticModel
+
+// Forward declaration in case StochasticModel is in a namespace
+// class StochasticModel; // Not strictly necessary if PointilismInterfaces.h is included correctly
+
+namespace Pointilism
+{
+
+class PresetManager
+{
+public:
+    /**
+     * Constructor.
+     * @param model A reference to the StochasticModel to be managed.
+     */
+    PresetManager(StochasticModel& model);
+
+    /**
+     * Saves the current state of the StochasticModel to a JSON file.
+     * @param fileToSave The juce::File object representing the file to save to.
+     * @return True if saving was successful, false otherwise.
+     */
+    bool savePreset(const juce::File& fileToSave);
+
+    /**
+     * Loads the state of the StochasticModel from a JSON file.
+     * @param fileToLoad The juce::File object representing the file to load from.
+     * @return True if loading was successful, false otherwise.
+     */
+    bool loadPreset(const juce::File& fileToLoad);
+
+private:
+    StochasticModel& model_;
+
+    // Helper to convert enum to string and vice-versa for serialization
+    // This is important because nlohmann::json doesn't automatically handle enums well.
+    // We'll store the enum as its underlying integer type or a string.
+    // For TemporalDistribution, int is fine.
+};
+
+} // namespace Pointilism

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries_system(${PROJECT_NAME} PUBLIC juce::juce_audio_utils)
 target_link_libraries(
   ${PROJECT_NAME} PUBLIC juce::juce_recommended_config_flags juce::juce_recommended_lto_flags
                          juce::juce_recommended_warning_flags
+                         nlohmann_json::nlohmann_json
 )
 
 # These definitions are recommended by JUCE.


### PR DESCRIPTION
This commit introduces the PresetManager class, responsible for serializing and deserializing the state of the StochasticModel to/from JSON files.

Key changes include:

1.  Created `Source/Data/PresetManager.h` and `Source/Data/PresetManager.cpp`:
    *   `PresetManager` constructor takes a `StochasticModel` reference.
    *   `savePreset(const juce::File&)` saves parameters to JSON.
    *   `loadPreset(const juce::File&)` loads parameters from JSON,
        including error handling for file I/O and parsing.

2.  Updated `plugin/source/PointilismInterfaces.h`:
    *   Added a comprehensive set of "global" parameters to `StochasticModel`
        (e.g., globalDensity, globalPitchOffset, globalNumVoices, etc.).
    *   For each global parameter, added an `std::atomic` member,
        a public getter, and a public setter method.
    *   This makes these parameters accessible for serialization.

3.  Integrated `nlohmann/json` library:
    *   Added `nlohmann/json` (v3.11.3) as a dependency via CPM in the
        root `CMakeLists.txt`.
    *   Linked `nlohmann_json::nlohmann_json` to the plugin target in
        `plugin/CMakeLists.txt`.

4.  Refined `PresetManager.cpp`:
    *   Corrected the scope of `TemporalDistribution` enum to
        `StochasticModel::TemporalDistribution` during loading.

The PresetManager currently serializes global synthesis parameters. Further work could extend this to per-voice parameters if the StochasticModel is updated to support distinct per-voice configurations through its interface.