### PR TITLE
Add CMake preset for Linux container builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,6 +32,15 @@
       "name": "Xcode",
       "generator": "Xcode",
       "binaryDir": "xcode-build"
+    },
+    {
+      "name": "linux-container",
+      "generator": "Unix Makefiles",
+      "binaryDir": "linux-container-build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -50,6 +59,10 @@
     {
       "name": "Xcode",
       "configurePreset": "Xcode"
+    },
+    {
+      "name": "linux-container",
+      "configurePreset": "linux-container"
     }
   ],
   "testPresets": [
@@ -77,6 +90,15 @@
       "inherits": "default",
       "configurePreset": "Xcode",
       "configuration": "Debug"
+    },
+    {
+      "name": "linux-container",
+      "configurePreset": "linux-container",
+      "output": { "outputOnFailure": true },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": false
+      }
     }
   ]
 }


### PR DESCRIPTION
This commit introduces new CMake presets (`configure`, `build`, and `test`) named 'linux-container'. These presets are configured to use the "Unix Makefiles" generator and are intended for use within a Linux container environment.

The 'linux-container' preset:
- Uses "Unix Makefiles" as the CMake generator.
- Sets the build type to "Debug".
- Enables export of compile commands.
- Configures test execution to output on failure and continue on non-critical test failures.