### PR TITLE
feat: Dockerize build environment for CI and local use

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,34 +9,28 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: false # Keep this if you want all jobs to run even if one fails
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        build_type: [Debug]
+        build_type: [Debug] # Kept original Debug, can be expanded later
         include:
-          - os: ubuntu-latest
-            name: Build ubuntu-latest Debug (Ninja)
-            build_type: Debug # Explicitly state build_type for clarity
+          - build_type: Debug
+            name: Build Debug (Ninja) # Simplified name
             cmake_generator_flags: -G Ninja
 
     name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest # Job runs on an ubuntu-latest host
+
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/pointilism/pointilsynth-build-env:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Cache dependencies
-      id: cache-libs
-      uses: actions/cache@v4
-      with:
-        path: ${{github.workspace}}/libs
-        key: libs-${{ matrix.os }}
-
-    - name: Install Linux dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libfreetype6-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libasound2-dev libwebkit2gtk-4.1-dev libgtk-3-dev
+    # Cache dependencies and Install Linux dependencies steps are removed
+    # as they are now part of the Docker image.
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -52,4 +46,3 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{ matrix.build_type }} --output-on-failure
-

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,38 @@
+name: Publish Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          target: base # Build only the 'base' stage
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/pointilism/pointilsynth-build-env:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM ubuntu:22.04
+# Stage 1: Base image with all dependencies
+FROM ubuntu:22.04 AS base
 
+# Install dependencies
+# Combine all apt-get install commands into a single RUN instruction to reduce layer count
+# Add libasound2-dev and libgtk-3-dev from the GitHub workflow
+# Remove duplicate libxcursor-dev entry
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     git \
@@ -10,19 +15,23 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     openssh-client \
     libjack-jackd2-dev \
     ladspa-sdk \
-    libcurl4-openssl-dev  \
+    libcurl4-openssl-dev \
     libfreetype6-dev \
-    libx11-dev  \
-    libxcomposite-dev  \
-    libxcursor-dev  \
-    libxcursor-dev  \
-    libxext-dev  \
-    libxinerama-dev  \
+    libx11-dev \
+    libxcomposite-dev \
+    libxcursor-dev \
+    libxext-dev \
+    libxinerama-dev \
     libxrandr-dev \
     libxrender-dev \
     libwebkit2gtk-4.1-dev \
-    libglu1-mesa-dev  \
-    mesa-common-dev
+    libglu1-mesa-dev \
+    mesa-common-dev \
+    libasound2-dev \
+    libgtk-3-dev
+
+# Stage 2: Builder image
+FROM base AS builder
 
 # Set the working directory
 WORKDIR /app
@@ -30,8 +39,11 @@ WORKDIR /app
 # Copy the project source code
 COPY . .
 
-# Configure the linux-container preset
+# Configure the CMake project using the linux-container preset
 RUN cmake --preset linux-container
 
-# Build the makefile project
+# Build the project
 RUN cmake --build build
+
+# Run tests
+RUN ctest --test-dir build --output-on-failure

--- a/README.md
+++ b/README.md
@@ -148,45 +148,50 @@ cd build/test/PointilSynthTests_artefacts/Debug/
 ./PointilSynth_Test # Or PointilSynth_Test.exe on Windows
 ```
 
-## For the Curious & Sound Designers
+## Dockerized Build Environment
 
-### The Synthesis Technique: Pointillistic Stochastic Granular Synthesis
+### Overview
+This project uses a Dockerized environment to ensure consistent builds and manage all necessary dependencies. The configuration for this environment is defined in the `Dockerfile` located in the root of the repository, which uses a multi-stage build approach.
 
-This instrument uses **granular synthesis**, where sound is constructed from tiny segments of audio called "grains." Instead of playing a continuous sound, it plays many small grains, often overlapping, to create complex textures.
+### Using Docker for Local Development
 
-The "pointillistic" aspect refers to how these grains are generated and distributed, much like dots of paint in a pointillist painting. Each grain can have unique properties.
+You can use Docker to create a local development environment with all dependencies pre-installed.
 
-The "stochastic" part means that these properties (like pitch, duration, pan, start time) are not fixed but are determined by probability distributions. You, the user, control the *shape* of these probabilities. For example, you don't set an exact pitch for all grains; you set a *central* pitch and a *dispersion* range, and the actual pitch of each grain is randomly chosen within that defined probabilistic range. This allows for the creation of sounds that feel organic, evolving, and unpredictable, yet controllable.
+**Build the `builder` stage for development and testing:**
+This command builds the `builder` stage from the Dockerfile, which includes source code, configures CMake, and builds the project. This is useful if you want to replicate the CI build or run all tests as defined in the Dockerfile.
+```bash
+docker build --target builder -t pointilsynth-builder .
+```
 
-### Visualization
+**Interactive Shell with Dependencies (`base` image):**
+For a more interactive development workflow, you can build the `base` image (which only contains dependencies) and then run a container with your local source code mounted.
 
-The central 2D visualization is key to understanding what's happening:
+1.  Build the `base` image (if you haven't already or want the latest version):
+    ```bash
+    docker build --target base -t pointilsynth-build-env .
+    ```
+2.  Run an interactive shell, mounting your current project directory into the container:
+    ```bash
+    docker run -it --rm -v "$(pwd):/app" -w /app pointilsynth-build-env bash
+    ```
+    Inside this shell, you'll have all dependencies available (clang, cmake, ninja, etc.) and can run CMake configuration, build steps, or tests manually.
 
-*   **X-axis (Horizontal):** Represents the stereo position (panning) of a grain. Grains to the left are panned left, grains to the right are panned right.
-*   **Y-axis (Vertical):** Represents the pitch of a grain. Higher grains have higher pitches.
-*   **Appearance (Color, Size - *Planned*):** The visual properties of a grain (e.g., its color or size) will eventually reflect other properties like its audio source or duration, giving you an immediate visual summary of the texture's composition.
+### Build Environment Image (`base` stage)
+The `base` stage of the `Dockerfile` is specifically designed to create a build environment image. This image contains all the compilers, libraries, and tools needed to build the project.
 
-By watching the visualization, you can intuitively grasp how the parameters you adjust are affecting the cloud of sound grains.
+This image is published to the GitHub Container Registry (GHCR) at:
+`ghcr.io/YOUR_GITHUB_USERNAME_OR_ORG/pointilism/pointilsynth-build-env:latest`
 
-### Creative Uses
+This is the exact image used by our GitHub Actions Continuous Integration (CI) workflow (`.github/workflows/cmake.yml`) to build and test the project, ensuring consistency between local and CI environments.
 
-This synth excels at:
+### Updating the `base` Image in GitHub Container Registry
+The `base` build environment image is automatically rebuilt and published to GHCR by the `.github/workflows/publish-docker-image.yml` workflow.
 
-*   **Atmospheric Pads:** Create dense, evolving soundscapes with subtle internal movement.
-*   **Complex Textures:** Generate rich, detailed sonic fabrics from any source audio.
-*   **Rhythmic Pulses:** Use the temporal distribution controls to create intricate, non-traditional rhythmic patterns.
-*   **Sound Effects:** Design unique and unusual sound effects by manipulating grain properties.
-*   **Experimental Sound Design:** Explore the boundaries of granular synthesis and stochastic processes.
+This process is triggered automatically on pushes to the `main` branch if any of the following files are modified:
+*   `Dockerfile`
+*   Any file within the `.github/workflows/` directory (e.g., changes to the publishing workflow itself).
 
-## Current Status & Roadmap
-
-This project is under active development. Key development phases (based on `jules_docs/sprint_master_plan.md`):
-
-*   **Core Engine & Stochastic Controls (Complete):** The fundamental sound generation and parameter logic are in place.
-*   **UI, Visualization & Preset Management (In Progress/Nearing Completion):** The main user interface, real-time visualization, and preset system are being finalized.
-*   **Modulation System (V2 - Future):** Planned features include LFOs and ADSR envelopes for animating parameters over time.
-
-See `jules_docs/sprint_master_plan.md` for more details on past and future development sprints.
+The workflow can also be triggered manually from the "Actions" tab in the GitHub repository if an immediate rebuild and publish are needed.
 
 ## License
 


### PR DESCRIPTION
This change introduces a Dockerized build environment to streamline CI builds and provide a consistent development environment.

Key changes:
- Modified the Dockerfile to be a multi-stage build:
  - A `base` stage installs all system dependencies and build tools. This image is published to GHCR.
  - A `builder` stage uses the `base` image to compile the project. This can be used for local development.
- Added a new GitHub Actions workflow (`.github/workflows/publish-docker-image.yml`):
  - Builds and publishes the `base` Docker image to `ghcr.io/OWNER/pointilism/pointilsynth-build-env:latest`.
  - Triggered on pushes to `main` affecting `Dockerfile` or workflows, or manually.
- Updated the existing CMake CI workflow (`.github/workflows/cmake.yml`):
  - Now pulls the `base` image from GHCR instead of installing dependencies in the job.
  - This significantly speeds up the CI process.
- Updated `README.md`:
  - Added a "Dockerized Build Environment" section.
  - Includes instructions on how to build and use the Docker images locally.
  - Explains how the `base` image is updated in GHCR.
  - Also removed some duplicated sections from the README.