### PR TITLE
Fix JUCE configuration for builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,7 +12,8 @@
       "binaryDir": "build",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_BUILD_TYPE": "Debug",
+        "JUCE_TARGET_ARCHITECTURE": "x86_64"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -92,14 +92,20 @@ This project is built with C++ and the JUCE framework.
 
 1.  Clone the repository.
 2.  Ensure you have a C++ compiler and CMake installed.
-3.  Ensure you have the JUCE framework installed and correctly set up in your development environment. The project uses JUCE to handle plugin formats, audio/MIDI I/O, and basic windowing.
-4.  Use CMake to generate project files for your IDE (e.g., Xcode, Visual Studio) or build system.
+3.  Install the required build dependencies for JUCE (Ubuntu/Debian example):
+    ```bash
+    sudo apt-get install -y libxrandr-dev libxinerama-dev libxext-dev \
+        libx11-dev libgtk-3-dev libwebkit2gtk-4.1-dev libasound2-dev \
+        libglu1-mesa-dev mesa-common-dev
+    ```
+4.  Ensure you have the JUCE framework installed and correctly set up in your development environment. The project uses JUCE to handle plugin formats, audio/MIDI I/O, and basic windowing.
+5.  Use CMake to generate project files for your IDE (e.g., Xcode, Visual Studio) or build system.
     ```bash
     # Example CMake configuration and build
     cmake -B build -S .
     cmake --build build
     ```
-5.  The build process will produce the VST3, AU, and AAX plugin targets.
+6.  The build process will produce the VST3, AU, and AAX plugin targets.
 
 ### Codebase Structure
 


### PR DESCRIPTION
## Summary
- configure JUCE architecture in CMake presets
- document required system packages for building with JUCE

## Testing
- `cmake --preset default`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684dd060c7008323ba5a5f2995341467