### PR TITLE
Add coverage reporting

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,7 +35,10 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -S . -B ${{github.workspace}}/build ${{ matrix.cmake_generator_flags }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+      run: cmake -S . -B ${{github.workspace}}/build ${{ matrix.cmake_generator_flags }} \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCMAKE_CXX_FLAGS="--coverage" \
+          -DCMAKE_C_FLAGS="--coverage"
 
     - name: Build
       # Build your program with the given configuration
@@ -46,3 +49,18 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{ matrix.build_type }} --output-on-failure
+
+    - name: Generate coverage report
+      working-directory: ${{github.workspace}}/build
+      run: |
+        gcovr -r .. --xml-pretty coverage.xml \
+              --html coverage.html --html-details \
+              --print-summary
+
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-${{ matrix.build_type }}
+        path: |
+          ${{github.workspace}}/build/coverage.xml
+          ${{github.workspace}}/build/coverage.html


### PR DESCRIPTION
## Summary
- build with coverage flags in CI
- add gcovr-based coverage report generation and artifact upload

## Testing
- `yamllint .github/workflows/cmake.yml`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS='--coverage' -DCMAKE_C_FLAGS='--coverage'` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684e1b13a6e88323a22320c32cca09ff