### PR TITLE
Add tests for standalone GrainEnvelope

### DIFF
--- a/GrainEnvelope.h
+++ b/GrainEnvelope.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cmath>
+#include <numbers>
+
+class GrainEnvelope {
+public:
+  enum class Shape { Trapezoid, Hann };
+
+  void setShape(Shape newShape) { shape_ = newShape; }
+
+  float getAmplitude(int currentSample, int totalDuration) const {
+    if (currentSample < 0 || totalDuration <= 0 ||
+        currentSample >= totalDuration) {
+      return 0.0f;
+    }
+
+    switch (shape_) {
+      case Shape::Hann: {
+        float n = static_cast<float>(currentSample);
+        float N = static_cast<float>(totalDuration);
+        return 0.5f *
+               (1.0f - std::cos(2.0f * std::numbers::pi_v<float> * n / N));
+      }
+      case Shape::Trapezoid: {
+        float pos = static_cast<float>(currentSample) /
+                    static_cast<float>(totalDuration);
+        if (pos < 0.1f) {
+          return pos / 0.1f;
+        } else if (pos < 0.9f) {
+          return 1.0f;
+        }
+        return 1.0f - (pos - 0.9f) / 0.1f;
+      }
+    }
+    return 0.0f;
+  }
+
+private:
+  Shape shape_{Shape::Trapezoid};
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ include(GoogleTest) # For GTest::gtest_main and gtest_discover_tests
 set(TEST_SOURCE_FILES
     source/DebugUIPanelTest.cpp
     source/GrainEnvelopeTest.cpp
+    source/StandaloneGrainEnvelopeTest.cpp
     source/OscillatorTest.cpp
     source/PluginEditorTest.cpp
     source/PluginProcessorTest.cpp
@@ -16,26 +17,31 @@ set(TEST_SOURCE_FILES
 )
 set_source_files_properties(${SOURCE_FILES} PROPERTIES COMPILE_OPTIONS "${PROJECT_WARNINGS_CXX}")
 
-juce_add_console_app(${PROJECT_NAME}
-    SOURCES 
-	${TEST_SOURCE_FILES}
-    MODULES
-        juce_core
-        juce_events
-        juce_gui_basics         # For DebugUIPanel and ScopedJuceInitialiser_GUI
-        juce_audio_processors # For APVTS in PanelTestFixtureA
-        juce_audio_basics
+juce_add_console_app(
+  ${PROJECT_NAME}
+  SOURCES
+  ${TEST_SOURCE_FILES}
+  MODULES
+  juce_core
+  juce_events
+  juce_gui_basics # For DebugUIPanel and ScopedJuceInitialiser_GUI
+  juce_audio_processors # For APVTS in PanelTestFixtureA
+  juce_audio_basics
 )
 
 target_link_libraries(
-  ${PROJECT_NAME} PUBLIC juce::juce_recommended_config_flags juce::juce_recommended_lto_flags juce::juce_audio_processors nlohmann_json::nlohmann_json 
-PRIVATE PointillisticSynth GTest::gtest_main
+  ${PROJECT_NAME}
+  PUBLIC juce::juce_recommended_config_flags
+         juce::juce_recommended_lto_flags
+         juce::juce_audio_processors
+         nlohmann_json::nlohmann_json
+  PRIVATE PointillisticSynth GTest::gtest_main
 )
-# juce::juce_recommended_warning_flags 
+# juce::juce_recommended_warning_flags
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-    ${GOOGLETEST_SOURCE_DIR}/googletest/include
-    "${CMAKE_CURRENT_SOURCE_DIR}/../plugin/include"
+target_include_directories(
+  ${PROJECT_NAME} PRIVATE ${GOOGLETEST_SOURCE_DIR}/googletest/include "${CMAKE_CURRENT_SOURCE_DIR}/../plugin/include"
+                          "${CMAKE_CURRENT_SOURCE_DIR}/.."
 )
 target_sources(${PROJECT_NAME} PRIVATE ${TEST_SOURCE_FILES})
 

--- a/test/source/StandaloneGrainEnvelopeTest.cpp
+++ b/test/source/StandaloneGrainEnvelopeTest.cpp
@@ -1,0 +1,21 @@
+#include "GrainEnvelope.h"
+#include <gtest/gtest.h>
+
+TEST(StandaloneGrainEnvelopeTest, HannShapeReturnsExpectedValues) {
+  GrainEnvelope env;
+  env.setShape(GrainEnvelope::Shape::Hann);
+  const int duration = 100;
+  EXPECT_FLOAT_EQ(env.getAmplitude(0, duration), 0.0f);
+  EXPECT_NEAR(env.getAmplitude(duration / 2, duration), 1.0f, 1e-6f);
+  EXPECT_NEAR(env.getAmplitude(duration - 1, duration), 0.0f, 1e-2f);
+}
+
+TEST(StandaloneGrainEnvelopeTest, TrapezoidShapeReturnsExpectedValues) {
+  GrainEnvelope env;
+  env.setShape(GrainEnvelope::Shape::Trapezoid);
+  const int duration = 100;
+  EXPECT_FLOAT_EQ(env.getAmplitude(0, duration), 0.0f);
+  EXPECT_FLOAT_EQ(env.getAmplitude(10, duration), 1.0f);
+  EXPECT_FLOAT_EQ(env.getAmplitude(50, duration), 1.0f);
+  EXPECT_NEAR(env.getAmplitude(99, duration), 0.1f, 1e-6f);
+}


### PR DESCRIPTION
## Summary
- expand tests to validate Hann and trapezoid envelopes

## Testing
- `pre-commit run --files test/CMakeLists.txt test/source/StandaloneGrainEnvelopeTest.cpp GrainEnvelope.h`
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`


------
https://chatgpt.com/codex/tasks/task_e_684e1e91d4b08323bee9f23350cd91b1