### PR TITLE
Implement main plugin editor layout

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -47,6 +47,7 @@ set(HEADER_FILES
     ${INCLUDE_DIR}/PointilismInterfaces.h
     ${INCLUDE_DIR}/PresetManager.h
     ${INCLUDE_DIR}/Resampler.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/PodComponent.h
 )
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCE_FILES} ${HEADER_FILES})
 

--- a/plugin/include/PodComponent.h
+++ b/plugin/include/PodComponent.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace audio_plugin {
+
+class PodComponent : public juce::Component {
+public:
+  PodComponent() = default;
+  ~PodComponent() override = default;
+
+private:
+  JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PodComponent)
+};
+
+}  // namespace audio_plugin

--- a/plugin/include/Pointilsynth/PluginEditor.h
+++ b/plugin/include/Pointilsynth/PluginEditor.h
@@ -1,31 +1,38 @@
 #pragma once
 
-
-#include "PluginProcessor.h" // Adjusted path
-#include "DebugUIPanel.h"       // Added for DebugUIPanel
-// PointilismInterfaces.h is included by PluginProcessor.h, which is included above.
-// If direct use of StochasticModel type was needed here, an include would be good:
-// #include "../../source/PointilismInterfaces.h"
+#include "PluginProcessor.h"  // Adjusted path
+#include "DebugUIPanel.h"     // Added for DebugUIPanel
+#include "PodComponent.h"     // Placeholder pod controls
+// PointilismInterfaces.h is included by PluginProcessor.h, which is included
+// above. If direct use of StochasticModel type was needed here, an include
+// would be good: #include "../../source/PointilismInterfaces.h"
 
 namespace audio_plugin {
 
-class PointillisticSynthAudioProcessorEditor : public juce::AudioProcessorEditor {
+class PointillisticSynthAudioProcessorEditor
+    : public juce::AudioProcessorEditor {
 public:
-    explicit PointillisticSynthAudioProcessorEditor(audio_plugin::AudioPluginAudioProcessor&);
-    ~PointillisticSynthAudioProcessorEditor() override;
+  explicit PointillisticSynthAudioProcessorEditor(
+      audio_plugin::AudioPluginAudioProcessor&);
+  ~PointillisticSynthAudioProcessorEditor() override;
 
-    void paint(juce::Graphics&) override;
-    void resized() override;
+  void paint(juce::Graphics&) override;
+  void resized() override;
 
 private:
-    // This reference is provided as a quick way for your editor to
-    // access the processor object that created it.
-    audio_plugin::AudioPluginAudioProcessor& processorRef;
+  // This reference is provided as a quick way for your editor to
+  // access the processor object that created it.
+  audio_plugin::AudioPluginAudioProcessor& processorRef;
 
-    DebugUIPanel debugUIPanel; // Added DebugUIPanel member
-  
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PointillisticSynthAudioProcessorEditor)
+  DebugUIPanel debugUIPanel;  // Added DebugUIPanel member
 
+  PodComponent pitchPod;
+  PodComponent densityPod;
+  PodComponent durationPod;
+  PodComponent panPod;
+
+  JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(
+      PointillisticSynthAudioProcessorEditor)
 };
 
-} // namespace audio_plugin
+}  // namespace audio_plugin

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -1,43 +1,54 @@
 #include "Pointilsynth/PluginEditor.h"
-#include "Pointilsynth/PluginProcessor.h" // Ensure this path is correct based on include directories
+#include "Pointilsynth/PluginProcessor.h"  // Ensure this path is correct based on include directories
 
 namespace audio_plugin {
 
 PointillisticSynthAudioProcessorEditor::PointillisticSynthAudioProcessorEditor(
     audio_plugin::AudioPluginAudioProcessor& p)
-    : juce::AudioProcessorEditor(&p), processorRef(p), debugUIPanel(processorRef.getStochasticModel()) {
-    // Add and make visible the PodComponents
+    : juce::AudioProcessorEditor(&p),
+      processorRef(p),
+      debugUIPanel(processorRef.getStochasticModel()) {
+  addAndMakeVisible(pitchPod);
+  addAndMakeVisible(densityPod);
+  addAndMakeVisible(durationPod);
+  addAndMakeVisible(panPod);
 
-    // Set the size of the editor window.
-    setSize(600, 400); // Example size, can be adjusted
-
+  setSize(600, 400);  // Example size, can be adjusted
 }
 
-PointillisticSynthAudioProcessorEditor::~PointillisticSynthAudioProcessorEditor() {}
+PointillisticSynthAudioProcessorEditor::
+    ~PointillisticSynthAudioProcessorEditor() {}
 
 void PointillisticSynthAudioProcessorEditor::paint(juce::Graphics& g) {
-    // Fill the background
-    g.fillAll(getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
+  // Fill the background
+  g.fillAll(
+      getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
 
-    // You can add drawing code here for the visualization area if needed,
-    // or leave it blank if it's handled by another component.
-    // For now, let's draw a placeholder for the visualization area.
-    auto visArea = getLocalBounds().removeFromTop(getHeight() * 2 / 3);
-    g.setColour(juce::Colours::darkgrey);
-    g.fillRect(visArea);
-    g.setColour(juce::Colours::white);
-    g.drawText("Visualization Area", visArea, juce::Justification::centred, false);
+  // You can add drawing code here for the visualization area if needed,
+  // or leave it blank if it's handled by another component.
+  // For now, let's draw a placeholder for the visualization area.
+  auto visArea = getLocalBounds().removeFromTop(getHeight() * 2 / 3);
+  g.setColour(juce::Colours::darkgrey);
+  g.fillRect(visArea);
+  g.setColour(juce::Colours::white);
+  g.drawText("Visualization Area", visArea, juce::Justification::centred,
+             false);
 }
 
 void PointillisticSynthAudioProcessorEditor::resized() {
-    auto bounds = getLocalBounds();
+  auto bounds = getLocalBounds();
 
-    // Top two-thirds for visualization (currently empty or placeholder)
-    bounds.removeFromTop(getHeight() * 2 / 3);
+  // Top two-thirds for visualization (currently empty or placeholder)
+  bounds.removeFromTop(getHeight() * 2 / 3);
 
-    // Bottom third for the pods
+  // Bottom third for the pods
+  auto podArea = bounds;
+  auto podWidth = podArea.getWidth() / 4;
 
-
+  pitchPod.setBounds(podArea.removeFromLeft(podWidth));
+  densityPod.setBounds(podArea.removeFromLeft(podWidth));
+  durationPod.setBounds(podArea.removeFromLeft(podWidth));
+  panPod.setBounds(podArea);
 }
 
-} // namespace audio_plugin
+}  // namespace audio_plugin

--- a/test/source/UI/PodComponentTest.cpp
+++ b/test/source/UI/PodComponentTest.cpp
@@ -1,15 +1,15 @@
-#include "Pointilsynth/UI/PodComponent.h" // Defines audio_plugin::PodComponent
+#include "PodComponent.h"  // Defines audio_plugin::PodComponent
 #include <gtest/gtest.h>
-#include <juce_gui_basics/juce_gui_basics.h> // For ScopedJuceInitialiser_GUI
+#include <juce_gui_basics/juce_gui_basics.h>  // For ScopedJuceInitialiser_GUI
 
 namespace audio_plugin {
 // Minimal ScopedJuceInitialiser_GUI for tests needing it.
 struct JuceGuiTestFixture : public ::testing::Test {
-    JuceGuiTestFixture() = default;
-    juce::ScopedJuceInitialiser_GUI libraryInitialiser;
+  JuceGuiTestFixture() = default;
+  juce::ScopedJuceInitialiser_GUI libraryInitialiser;
 };
 
 TEST_F(JuceGuiTestFixture, PodComponentCanConstruct) {
-    EXPECT_NO_THROW(std::make_unique<PodComponent>());
+  EXPECT_NO_THROW(std::make_unique<PodComponent>());
 }
-} // namespace audio_plugin
+}  // namespace audio_plugin


### PR DESCRIPTION
## Summary
- add placeholder `PodComponent` class
- register `PodComponent` in build
- expose four pods in `PluginEditor`
- lay out pods across bottom third of the window
- adapt tests to new include path
- add leak detector to `PodComponent`

## Testing
- `cmake --preset default` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684e1ffe98a88323b394accd16bdccc0