### PR TITLE
Refactor to central config manager with APVTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This project is built with C++ and the JUCE framework.
 4.  Ensure you have the JUCE framework installed and correctly set up in your development environment. The project uses JUCE to handle plugin formats, audio/MIDI I/O, and basic windowing.
 5.  Use CMake to generate project files for your IDE (e.g., Xcode, Visual Studio) or build system.
     ```bash
-    # Example CMake configuration and build
+#Example CMake configuration and build
     cmake -B build -S .
     cmake --build build
     ```
@@ -137,9 +137,9 @@ All core source code for the synthesizer, including the audio engine, UI compone
 *   Please follow the coding style defined in `.clang-format`.
 *   Consider using the pre-commit hooks defined in `.pre-commit-config.yaml` to ensure code quality before committing.
     ```bash
-    # Install pre-commit (if you haven't already)
+#Install pre - commit(if you haven't already)
     pip install pre-commit
-    # Set up the git hook scripts
+#Set up the git hook scripts
     pre-commit install
     ```
 *   Write unit tests for new features or bug fixes.
@@ -150,17 +150,39 @@ The project includes a suite of unit tests. After configuring and building with 
 `default` CMake preset, you can invoke the tests directly through `ctest`:
 
 ```bash
-# Configure and build using the default preset
+#Configure and build using the default preset
 cmake --preset default
 cmake --build --preset default
 
-# Run the test suite
+#Run the test suite
 ctest --preset default
 ```
 
 The `-C` flag is only meaningful when using a multi-config generator. Since the
 repository defaults to Ninja (a single-config generator), using `ctest -C debug`
 or similar will report "No tests were found".
+
+### ConfigManager Usage
+
+`ConfigManager` is a thin wrapper around JUCE's
+`AudioProcessorValueTreeState` (APVTS) that acts as the central store for all
+plugin parameters. Each class that needs parameter access receives a shared
+pointer to this singleton.
+
+**Adding a parameter**
+
+1. Declare a new ID constant in `ConfigManager::ParamID`.
+2. Add the corresponding `juce::RangedAudioParameter` to
+   `ConfigManager::createLayout()` with an initial value and range.
+
+**Connecting UI controls**
+
+UI components create `SliderAttachment` or `ComboBoxAttachment` objects using
+the parameter ID. Non-UI classes like `StochasticModel` register callbacks via
+`ConfigManager::addListener` to react whenever the parameter value changes.
+
+This pattern ensures all parameter updates are thread safe and serialized
+through the APVTS, simplifying state save/load and automation handling.
 
 ## Dockerized Build Environment
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ the parameter ID. Non-UI classes like `StochasticModel` register callbacks via
 
 This pattern ensures all parameter updates are thread safe and serialized
 through the APVTS, simplifying state save/load and automation handling.
+Always obtain the `ConfigManager` instance from the processor so that every
+component shares the same parameter state.
 
 ## Dockerized Build Environment
 

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -46,12 +46,14 @@ set(SOURCE_FILES
     source/AudioEngine.cpp
     source/PluginEditor.cpp
     source/DebugUIPanel.cpp
+    source/ConfigManager.cpp
     source/StochasticModel.cpp
     source/PresetManager.cpp
 )
 # Optional; includes header files in the project file tree in Visual Studio
 set(HEADER_FILES
     ${INCLUDE_DIR}/DebugUIPanel.h
+    ${INCLUDE_DIR}/ConfigManager.h
     ${INCLUDE_DIR}/GrainEnvelope.h
     ${INCLUDE_DIR}/Oscillator.h
     ${INCLUDE_DIR}/PluginEditor.h
@@ -64,8 +66,10 @@ set(HEADER_FILES
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCE_FILES} ${HEADER_FILES})
 
 # Sets the include directories of the plugin project.
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/include/Pointilsynth ${CMAKE_BINARY_DIR}/include)
-
+target_include_directories(
+  ${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/include/Pointilsynth
+                         ${CMAKE_BINARY_DIR}/include
+)
 
 # Links to all necessary dependencies. The present ones are recommended by JUCE.
 # If you use one of the additional modules, like the DSP module, you need to specify it here.

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -43,6 +43,7 @@ juce_add_plugin(
 # Sets the source files of the plugin project.
 set(SOURCE_FILES
     source/AudioEngine.cpp
+    source/ConfigManager.cpp
     source/DebugUIPanel.cpp
     source/PluginProcessor.cpp
     source/PluginEditor.cpp

--- a/plugin/include/Pointilsynth/ConfigManager.h
+++ b/plugin/include/Pointilsynth/ConfigManager.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <memory>
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+class ConfigManager {
+public:
+  struct ParamID {
+    static constexpr const char* pitch = "pitch";
+    static constexpr const char* dispersion = "dispersion";
+    static constexpr const char* avgDuration = "avgDuration";
+    static constexpr const char* durationVariation = "durationVariation";
+    static constexpr const char* pan = "pan";
+    static constexpr const char* panSpread = "panSpread";
+    static constexpr const char* density = "density";
+    static constexpr const char* temporalDistribution = "temporalDistribution";
+  };
+
+  using Callback = std::function<void(float)>;
+
+  static std::shared_ptr<ConfigManager> getInstance(
+      juce::AudioProcessor* processor = nullptr);
+  static void resetInstance();
+  juce::AudioProcessorValueTreeState& getAPVTS();
+  void addListener(const juce::String& paramID, Callback cb);
+
+private:
+  class FunctionListener : public juce::AudioProcessorValueTreeState::Listener {
+  public:
+    explicit FunctionListener(Callback fn) : fn_(std::move(fn)) {}
+    void parameterChanged(const juce::String&, float newValue) override {
+      fn_(newValue);
+    }
+    Callback fn_;
+  };
+
+  explicit ConfigManager(juce::AudioProcessor* processor);
+  static juce::AudioProcessorValueTreeState::ParameterLayout createLayout();
+
+  juce::AudioProcessorValueTreeState apvts_;
+  juce::AudioProcessor* owner_{nullptr};
+  std::unordered_map<juce::String,
+                     std::vector<std::unique_ptr<FunctionListener>>>
+      listeners_;
+
+  JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ConfigManager)
+};

--- a/plugin/include/Pointilsynth/DebugUIPanel.h
+++ b/plugin/include/Pointilsynth/DebugUIPanel.h
@@ -1,54 +1,59 @@
 #pragma once
 
 #include <juce_gui_basics/juce_gui_basics.h>
-#include "PointilismInterfaces.h" // Assuming this is the correct path
+#include "PointilismInterfaces.h"  // Assuming this is the correct path
+#include "ConfigManager.h"
 
-class DebugUIPanel : public juce::Component
-{
+class DebugUIPanel : public juce::Component {
 public:
-    // Constructor that takes a pointer to the StochasticModel
-    DebugUIPanel(StochasticModel* model);
-    ~DebugUIPanel() override;
+  // Constructor that takes a ConfigManager
+  explicit DebugUIPanel(std::shared_ptr<ConfigManager> cfg);
+  ~DebugUIPanel() override;
 
-    // juce::Component overrides
-    void paint(juce::Graphics& g) override;
-    void resized() override;
+  // juce::Component overrides
+  void paint(juce::Graphics& g) override;
+  void resized() override;
 
 private:
-    // Pointer to the audio engine's stochastic model
-    StochasticModel* stochasticModel;
+  // Config manager
+  std::shared_ptr<ConfigManager> configManager;
 
-    // UI Components
-    juce::Slider pitchSlider;
-    juce::Label pitchLabel;
-    juce::Slider dispersionSlider;
-    juce::Label dispersionLabel;
+  // UI Components
+  juce::Slider pitchSlider;
+  juce::Label pitchLabel;
+  juce::Slider dispersionSlider;
+  juce::Label dispersionLabel;
 
-    juce::Slider durationSlider;
-    juce::Label durationLabel;
-    juce::Slider durationVariationSlider;
-    juce::Label durationVariationLabel;
+  juce::Slider durationSlider;
+  juce::Label durationLabel;
+  juce::Slider durationVariationSlider;
+  juce::Label durationVariationLabel;
 
-    juce::Slider panSlider;
-    juce::Label panLabel;
-    juce::Slider panSpreadSlider;
-    juce::Label panSpreadLabel;
+  juce::Slider panSlider;
+  juce::Label panLabel;
+  juce::Slider panSpreadSlider;
+  juce::Label panSpreadLabel;
 
-    juce::Slider densitySlider;
-    juce::Label densityLabel;
+  juce::Slider densitySlider;
+  juce::Label densityLabel;
 
-    juce::ComboBox temporalDistributionComboBox;
-    juce::Label temporalDistributionLabel;
+  juce::ComboBox temporalDistributionComboBox;
+  juce::Label temporalDistributionLabel;
 
-    // Callback methods for UI components
-    void pitchSliderChanged();
-    void dispersionSliderChanged();
-    void durationSliderChanged();
-    void durationVariationSliderChanged();
-    void panSliderChanged();
-    void panSpreadSliderChanged();
-    void densitySliderChanged();
-    void temporalDistributionChanged();
+  // Parameter attachments (declared after the components they reference so that
+  // they are destroyed first).
+  using SliderAttachment = juce::AudioProcessorValueTreeState::SliderAttachment;
+  using ComboBoxAttachment =
+      juce::AudioProcessorValueTreeState::ComboBoxAttachment;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DebugUIPanel)
+  std::unique_ptr<SliderAttachment> pitchAttachment;
+  std::unique_ptr<SliderAttachment> dispersionAttachment;
+  std::unique_ptr<SliderAttachment> durationAttachment;
+  std::unique_ptr<SliderAttachment> durationVariationAttachment;
+  std::unique_ptr<SliderAttachment> panAttachment;
+  std::unique_ptr<SliderAttachment> panSpreadAttachment;
+  std::unique_ptr<SliderAttachment> densityAttachment;
+  std::unique_ptr<ComboBoxAttachment> temporalDistributionAttachment;
+
+  JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DebugUIPanel)
 };

--- a/plugin/include/Pointilsynth/PluginProcessor.h
+++ b/plugin/include/Pointilsynth/PluginProcessor.h
@@ -1,14 +1,18 @@
 #pragma once
 
 #include <juce_audio_processors/juce_audio_processors.h>
-#include "PointilismInterfaces.h" // Added for AudioEngine and StochasticModel
+#include "PointilismInterfaces.h"  // Added for AudioEngine and StochasticModel
+#include "ConfigManager.h"
 
 namespace audio_plugin {
 class AudioPluginAudioProcessor : public juce::AudioProcessor {
 public:
   AudioPluginAudioProcessor();
   // Provide access to the StochasticModel for the editor
-  StochasticModel* getStochasticModel() { return audioEngine.getStochasticModel(); }
+  StochasticModel* getStochasticModel() {
+    return audioEngine.getStochasticModel();
+  }
+  std::shared_ptr<ConfigManager> getConfigManager() { return configManager; }
   ~AudioPluginAudioProcessor() override;
 
   void prepareToPlay(double sampleRate, int samplesPerBlock) override;
@@ -39,7 +43,8 @@ public:
   void setStateInformation(const void* data, int sizeInBytes) override;
 
 private:
-  AudioEngine audioEngine; // Added AudioEngine member
+  std::shared_ptr<ConfigManager> configManager;
+  AudioEngine audioEngine;  // Added AudioEngine member
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)
 };

--- a/plugin/include/Pointilsynth/PointilismInterfaces.h
+++ b/plugin/include/Pointilsynth/PointilismInterfaces.h
@@ -4,8 +4,9 @@
 #include <juce_core/juce_core.h>
 #include <juce_audio_basics/juce_audio_basics.h>
 
-#include "Pointilsynth/Oscillator.h"
-#include "Pointilsynth/GrainEnvelope.h"
+#include "Oscillator.h"
+#include "GrainEnvelope.h"
+#include "ConfigManager.h"
 
 #include <vector>
 #include <random>

--- a/plugin/include/Pointilsynth/PointilismInterfaces.h
+++ b/plugin/include/Pointilsynth/PointilismInterfaces.h
@@ -19,22 +19,21 @@
  * assigned at the moment of its creation. The AudioEngine will manage a
  * collection of these.
  */
-struct Grain
-{
-    bool isAlive = true;  // Flag to mark for cleanup when the grain is finished.
-    int id = 0;           // Unique identifier for visualization purposes.
+struct Grain {
+  bool isAlive = true;  // Flag to mark for cleanup when the grain is finished.
+  int id = 0;           // Unique identifier for visualization purposes.
 
-    // Core sonic properties
-    float pitch = 60.0f;          // MIDI note number. 
-    float pan = 0.0f;             // Stereo position from -1.0 (L) to 1.0 (R). 
-    float amplitude = 0.0f;       // Amplitude from 0.0 to 1.0. 
-    int durationInSamples = 0;    // Total lifetime of the grain in audio samples. 
+  // Core sonic properties
+  float pitch = 60.0f;        // MIDI note number.
+  float pan = 0.0f;           // Stereo position from -1.0 (L) to 1.0 (R).
+  float amplitude = 0.0f;     // Amplitude from 0.0 to 1.0.
+  int durationInSamples = 0;  // Total lifetime of the grain in audio samples.
 
-    // Playback state
-    int ageInSamples = 0;         // How many samples this grain has been playing.
-    double sourceSamplePosition = 0.0; // The starting position within the source audio file.
+  // Playback state
+  int ageInSamples = 0;  // How many samples this grain has been playing.
+  double sourceSamplePosition =
+      0.0;  // The starting position within the source audio file.
 };
-
 
 /**
  * @class StochasticModel
@@ -43,184 +42,225 @@ struct Grain
  * This class is the core of the "pointillistic" concept. It uses the C++
  * <random> library to generate properties for new grains based on user-defined
  * parameters. The UI thread will call the 'set' methods, and the audio thread
- * will call the 'generate' methods. Parameters are atomic to ensure thread safety.
+ * will call the 'generate' methods. Parameters are atomic to ensure thread
+ * safety.
  */
-class StochasticModel
-{
+class ConfigManager;  // Forward declaration
+
+class StochasticModel {
 public:
-    // This enum will be used by the UI to select the temporal distribution model. 
-    enum class TemporalDistribution
-    {
-        Uniform,
-        Poisson // Random
-    };
+  // This enum will be used by the UI to select the temporal distribution model.
+  enum class TemporalDistribution {
+    Uniform,
+    Poisson  // Random
+  };
 
-    //==============================================================================
-    // Parameter Setters (called by the UI thread)
-    //==============================================================================
-    void setPitchAndDispersion(float centralPitchValue, float dispersionValue) {
-        pitch.store(centralPitchValue);
-        dispersion.store(dispersionValue);
-        pitchDistribution = std::normal_distribution<float>(centralPitchValue, dispersionValue);
-    }
-    void setDurationAndVariation(float averageDurationMsValue, float variationValue);
-    void setPanAndSpread(float centralPanValue, float spreadValue) {
-        centralPan.store(centralPanValue);
-        panSpread.store(spreadValue);
-        panDistribution = std::normal_distribution<float>(centralPanValue, spreadValue);
-    }
-    void setGlobalDensity(float densityValue) { // Renamed from setDensity
-        globalDensity_.store(densityValue); // Updated from grainsPerSecond_ to globalDensity_ and parameter name
-        // If Poisson distribution rate depends on this, update here.
-        // e.g., if using globalDensity_ directly for poisson lambda:
-        // poissonDistribution_ = std::poisson_distribution<int>(densityValue);
-        // More likely, it's related to sampleRate: events_per_sample = densityValue / sampleRate
-        // And then lambda = events_per_sample * block_size for poisson events per block.
-        // This logic is typically in getSamplesUntilNextEvent() or similar.
-    }
-    void setGlobalMinDistance(float minDistValue) { globalMinDistance_.store(minDistValue); }
-    void setGlobalPitchOffset(int pitchOffsetValue) { globalPitchOffset_.store(pitchOffsetValue); }
-    void setGlobalPanOffset(float panOffsetValue) { globalPanOffset_.store(panOffsetValue); }
-    void setGlobalVelocityOffset(float velocityOffsetValue) { globalVelocityOffset_.store(velocityOffsetValue); }
-    void setGlobalDurationOffset(float durationOffsetValue) { globalDurationOffset_.store(durationOffsetValue); }
-    void setGlobalTempoSyncEnabled(bool tempoSyncEnabledValue) { globalTempoSyncEnabled_.store(tempoSyncEnabledValue); }
-    void setGlobalNumVoices(int numVoicesValue) { globalNumVoices_.store(numVoicesValue); }
-    void setGlobalNumGrains(int numGrainsValue) { globalNumGrains_.store(numGrainsValue); }
-    void setGlobalTemporalDistribution(TemporalDistribution modelValue) { // Renamed from setTemporalDistribution
-        globalTemporalDistribution_.store(modelValue); // Updated from temporalDistributionModel_
-    }
+  //==============================================================================
+  // Parameter Setters (called by the UI thread)
+  //==============================================================================
+  explicit StochasticModel(std::shared_ptr<ConfigManager> cfg = {});
 
-    //==============================================================================
-    // Parameter Getters (called by UI thread via DebugUIPanel)
-    //==============================================================================
-    float getPitch() const { return pitch.load(); }
-    float getDispersion() const { return dispersion.load(); }
-    float getAverageDurationMs() const { return averageDurationMs_.load(); }
-    float getDurationVariation() const { return durationVariation_.load(); }
-    float getCentralPan() const { return centralPan.load(); }
-    float getPanSpread() const { return panSpread.load(); }
-    float getGlobalDensity() const { return globalDensity_.load(); } // Renamed from getGrainsPerSecond
-    float getGlobalMinDistance() const { return globalMinDistance_.load(); }
-    int getGlobalPitchOffset() const { return globalPitchOffset_.load(); }
-    float getGlobalPanOffset() const { return globalPanOffset_.load(); }
-    float getGlobalVelocityOffset() const { return globalVelocityOffset_.load(); }
-    float getGlobalDurationOffset() const { return globalDurationOffset_.load(); }
-    bool isGlobalTempoSyncEnabled() const { return globalTempoSyncEnabled_.load(); } // Note: 'is' prefix for bool
-    int getGlobalNumVoices() const { return globalNumVoices_.load(); }
-    int getGlobalNumGrains() const { return globalNumGrains_.load(); }
-    TemporalDistribution getGlobalTemporalDistribution() const { return globalTemporalDistribution_.load(); } // Renamed from getTemporalDistributionModel
-    double getSampleRate() const { return sampleRate_.load(); }
+  void setPitchAndDispersion(float centralPitchValue, float dispersionValue) {
+    pitch.store(centralPitchValue);
+    dispersion.store(dispersionValue);
+    pitchDistribution =
+        std::normal_distribution<float>(centralPitchValue, dispersionValue);
+  }
+  void setDurationAndVariation(float averageDurationMsValue,
+                               float variationValue);
+  void setPanAndSpread(float centralPanValue, float spreadValue) {
+    centralPan.store(centralPanValue);
+    panSpread.store(spreadValue);
+    panDistribution =
+        std::normal_distribution<float>(centralPanValue, spreadValue);
+  }
+  void setGlobalDensity(float densityValue) {  // Renamed from setDensity
+    globalDensity_.store(densityValue);  // Updated from grainsPerSecond_ to
+                                         // globalDensity_ and parameter name
+    // If Poisson distribution rate depends on this, update here.
+    // e.g., if using globalDensity_ directly for poisson lambda:
+    // poissonDistribution_ = std::poisson_distribution<int>(densityValue);
+    // More likely, it's related to sampleRate: events_per_sample = densityValue
+    // / sampleRate And then lambda = events_per_sample * block_size for poisson
+    // events per block. This logic is typically in getSamplesUntilNextEvent()
+    // or similar.
+  }
+  void setGlobalMinDistance(float minDistValue) {
+    globalMinDistance_.store(minDistValue);
+  }
+  void setGlobalPitchOffset(int pitchOffsetValue) {
+    globalPitchOffset_.store(pitchOffsetValue);
+  }
+  void setGlobalPanOffset(float panOffsetValue) {
+    globalPanOffset_.store(panOffsetValue);
+  }
+  void setGlobalVelocityOffset(float velocityOffsetValue) {
+    globalVelocityOffset_.store(velocityOffsetValue);
+  }
+  void setGlobalDurationOffset(float durationOffsetValue) {
+    globalDurationOffset_.store(durationOffsetValue);
+  }
+  void setGlobalTempoSyncEnabled(bool tempoSyncEnabledValue) {
+    globalTempoSyncEnabled_.store(tempoSyncEnabledValue);
+  }
+  void setGlobalNumVoices(int numVoicesValue) {
+    globalNumVoices_.store(numVoicesValue);
+  }
+  void setGlobalNumGrains(int numGrainsValue) {
+    globalNumGrains_.store(numGrainsValue);
+  }
+  void setGlobalTemporalDistribution(
+      TemporalDistribution
+          modelValue) {  // Renamed from setTemporalDistribution
+    globalTemporalDistribution_.store(
+        modelValue);  // Updated from temporalDistributionModel_
+  }
 
+  //==============================================================================
+  // Parameter Getters (called by UI thread via DebugUIPanel)
+  //==============================================================================
+  float getPitch() const { return pitch.load(); }
+  float getDispersion() const { return dispersion.load(); }
+  float getAverageDurationMs() const { return averageDurationMs_.load(); }
+  float getDurationVariation() const { return durationVariation_.load(); }
+  float getCentralPan() const { return centralPan.load(); }
+  float getPanSpread() const { return panSpread.load(); }
+  float getGlobalDensity() const {
+    return globalDensity_.load();
+  }  // Renamed from getGrainsPerSecond
+  float getGlobalMinDistance() const { return globalMinDistance_.load(); }
+  int getGlobalPitchOffset() const { return globalPitchOffset_.load(); }
+  float getGlobalPanOffset() const { return globalPanOffset_.load(); }
+  float getGlobalVelocityOffset() const { return globalVelocityOffset_.load(); }
+  float getGlobalDurationOffset() const { return globalDurationOffset_.load(); }
+  bool isGlobalTempoSyncEnabled() const {
+    return globalTempoSyncEnabled_.load();
+  }  // Note: 'is' prefix for bool
+  int getGlobalNumVoices() const { return globalNumVoices_.load(); }
+  int getGlobalNumGrains() const { return globalNumGrains_.load(); }
+  TemporalDistribution getGlobalTemporalDistribution() const {
+    return globalTemporalDistribution_.load();
+  }  // Renamed from getTemporalDistributionModel
+  double getSampleRate() const { return sampleRate_.load(); }
 
-    //==============================================================================
-    // Value Generators (called by the AudioEngine thread)
-    //==============================================================================
+  //==============================================================================
+  // Value Generators (called by the AudioEngine thread)
+  //==============================================================================
 
-    /** Generates the number of samples to wait before triggering the next grain. */
-    int getSamplesUntilNextEvent();
+  /** Generates the number of samples to wait before triggering the next grain.
+   */
+  int getSamplesUntilNextEvent();
 
-    /** Fills a Grain struct with new, randomized properties based on the current model. */
-    void generateNewGrain(Grain& newGrain);
+  /** Fills a Grain struct with new, randomized properties based on the current
+   * model. */
+  void generateNewGrain(Grain& newGrain);
 
 private:
-    // Private members would include std::mt19937 for random number generation,
-    // and various std::distribution objects (e.g., normal_distribution,
-    // uniform_real_distribution, poisson_distribution) to model the parameters.
-    // Ensure randomEngine is seeded, e.g., in constructor or a dedicated init method.
-    std::mt19937 randomEngine { std::random_device{}() }; // Example seeding
-    std::poisson_distribution<int> poissonDistribution_ {10.0}; // Example initialization
-    std::uniform_real_distribution<float> uniformRealDistribution_ { -0.5f, 0.5f };
+  std::shared_ptr<ConfigManager> config_;
+  // Private members would include std::mt19937 for random number generation,
+  // and various std::distribution objects (e.g., normal_distribution,
+  // uniform_real_distribution, poisson_distribution) to model the parameters.
+  // Ensure randomEngine is seeded, e.g., in constructor or a dedicated init
+  // method.
+  std::mt19937 randomEngine{std::random_device{}()};  // Example seeding
+  std::poisson_distribution<int> poissonDistribution_{
+      10.0};  // Example initialization
+  std::uniform_real_distribution<float> uniformRealDistribution_{-0.5f, 0.5f};
 
-    // Parameters controlled by the UI (using std::atomic for thread-safety)
-    std::atomic<float> pitch { 60.0f };
-    std::atomic<float> dispersion { 12.0f }; // e.g. in semitones
-    std::atomic<float> averageDurationMs_ { 200.0f }; // e.g. in milliseconds
-    std::atomic<float> durationVariation_ { 0.25f }; // e.g. 25% variation
-    std::atomic<float> globalDensity_ { 10.0f }; // Formerly grainsPerSecond_
-    std::atomic<float> globalMinDistance_ { 0.0f }; // New parameter
-    std::atomic<int> globalPitchOffset_ { 0 }; // New parameter
-    std::atomic<float> globalPanOffset_ { 0.0f }; // New parameter
-    std::atomic<float> globalVelocityOffset_{0.0f};
-    std::atomic<float> globalDurationOffset_{0.0f};
-    std::atomic<bool> globalTempoSyncEnabled_{false};
-    std::atomic<int> globalNumVoices_{1};
-    std::atomic<int> globalNumGrains_{100};
-    std::atomic<TemporalDistribution> globalTemporalDistribution_ { TemporalDistribution::Uniform }; // Formerly temporalDistributionModel_
-    std::atomic<double> sampleRate_ { 44100.0 }; // Should be set by prepareToPlay in AudioEngine
-    std::atomic<float> centralPan { 0.0f }; // -1 (L) to 1 (R)
-    std::atomic<float> panSpread { 0.5f }; // 0 (no spread) to 1 (full spread)
+  // Parameters controlled by the UI (using std::atomic for thread-safety)
+  std::atomic<float> pitch{60.0f};
+  std::atomic<float> dispersion{12.0f};           // e.g. in semitones
+  std::atomic<float> averageDurationMs_{200.0f};  // e.g. in milliseconds
+  std::atomic<float> durationVariation_{0.25f};   // e.g. 25% variation
+  std::atomic<float> globalDensity_{10.0f};       // Formerly grainsPerSecond_
+  std::atomic<float> globalMinDistance_{0.0f};    // New parameter
+  std::atomic<int> globalPitchOffset_{0};         // New parameter
+  std::atomic<float> globalPanOffset_{0.0f};      // New parameter
+  std::atomic<float> globalVelocityOffset_{0.0f};
+  std::atomic<float> globalDurationOffset_{0.0f};
+  std::atomic<bool> globalTempoSyncEnabled_{false};
+  std::atomic<int> globalNumVoices_{1};
+  std::atomic<int> globalNumGrains_{100};
+  std::atomic<TemporalDistribution> globalTemporalDistribution_{
+      TemporalDistribution::Uniform};  // Formerly temporalDistributionModel_
+  std::atomic<double> sampleRate_{
+      44100.0};  // Should be set by prepareToPlay in AudioEngine
+  std::atomic<float> centralPan{0.0f};  // -1 (L) to 1 (R)
+  std::atomic<float> panSpread{0.5f};   // 0 (no spread) to 1 (full spread)
 
+  // Distributions - these should be updated when parameters change.
+  // For simplicity, the setters currently just store values. A more complete
+  // implementation would update these distributions in the setters.
+  std::normal_distribution<float> pitchDistribution{pitch.load(),
+                                                    dispersion.load()};
+  std::normal_distribution<float> panDistribution{centralPan.load(),
+                                                  panSpread.load()};
+  // Duration distribution might be normal or log-normal depending on desired
+  // behavior
+  std::normal_distribution<float> durationDistribution{
+      averageDurationMs_.load(),
+      averageDurationMs_.load() * durationVariation_.load()};
 
-    // Distributions - these should be updated when parameters change.
-    // For simplicity, the setters currently just store values. A more complete
-    // implementation would update these distributions in the setters.
-    std::normal_distribution<float> pitchDistribution { pitch.load(), dispersion.load() };
-    std::normal_distribution<float> panDistribution { centralPan.load(), panSpread.load() };
-    // Duration distribution might be normal or log-normal depending on desired behavior
-    std::normal_distribution<float> durationDistribution { averageDurationMs_.load(), averageDurationMs_.load() * durationVariation_.load() };
-
-public: // Public setter for sample rate, to be called by AudioEngine
-    void setSampleRate(double sr);
+public:  // Public setter for sample rate, to be called by AudioEngine
+  void setSampleRate(double sr);
 };
-
 
 /**
  * @class AudioEngine
  * @brief The high-performance heart of the instrument.
  *
- * This class is responsible for managing and rendering all active grains. It will
- * be driven by the main JUCE AudioProcessor's processBlock. Its goal is to maintain
- * high CPU efficiency while managing up to the target number of grains.
+ * This class is responsible for managing and rendering all active grains. It
+ * will be driven by the main JUCE AudioProcessor's processBlock. Its goal is to
+ * maintain high CPU efficiency while managing up to the target number of
+ * grains.
  */
-class AudioEngine
-{
+class AudioEngine {
 public:
-    enum class GrainSourceType
-    {
-        Oscillator,
-        AudioSample
-    };
+  enum class GrainSourceType { Oscillator, AudioSample };
 
-    AudioEngine() = default;
+  explicit AudioEngine(std::shared_ptr<ConfigManager> cfg = {});
 
-    /** Called by the host to prepare the engine for playback. */
-    void prepareToPlay(double sampleRate, int samplesPerBlock);
+  /** Called by the host to prepare the engine for playback. */
+  void prepareToPlay(double sampleRate, int samplesPerBlock);
 
-    /**
-     * Processes a block of audio. This is where all DSP happens.
-     * This method will be called repeatedly on the real-time audio thread.
-     */
-    void processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages);
+  /**
+   * Processes a block of audio. This is where all DSP happens.
+   * This method will be called repeatedly on the real-time audio thread.
+   */
+  void processBlock(juce::AudioBuffer<float>& buffer,
+                    juce::MidiBuffer& midiMessages);
 
-    /** Loads a user-provided audio file to be used as a grain source. */
-    void loadAudioSample(const juce::File& audioFile);
+  /** Loads a user-provided audio file to be used as a grain source. */
+  void loadAudioSample(const juce::File& audioFile);
 
-    /** Selects an internal waveform to be used as a grain source. */
-    void setGrainSource(int internalWaveformId);
+  /** Selects an internal waveform to be used as a grain source. */
+  void setGrainSource(int internalWaveformId);
 
-    /** Provides a non-owning pointer to the model for the UI to control. */
-    StochasticModel* getStochasticModel() { return &stochasticModel; }
+  /** Provides a non-owning pointer to the model for the UI to control. */
+  StochasticModel* getStochasticModel() { return &stochasticModel; }
 
 private:
-    double currentSampleRate = 44100.0;
-    int grainIdCounter = 0;
+  double currentSampleRate = 44100.0;
+  int grainIdCounter = 0;
 
-    // The model that dictates the properties of new grains.
-    StochasticModel stochasticModel;
+  // The model that dictates the properties of new grains.
+  StochasticModel stochasticModel;
 
-    // A pre-allocated vector to hold all active grains. We reserve to avoid
-    // real-time memory allocation. 
-    std::vector<Grain> grains;
+  std::shared_ptr<ConfigManager> config_;
 
-    // A counter to determine when to ask the StochasticModel for a new grain.
-    int samplesUntilNextGrain = 0;
+  // A pre-allocated vector to hold all active grains. We reserve to avoid
+  // real-time memory allocation.
+  std::vector<Grain> grains;
 
-    // Placeholder for the loaded audio file data. 
-    juce::AudioBuffer<float> sourceAudio;
+  // A counter to determine when to ask the StochasticModel for a new grain.
+  int samplesUntilNextGrain = 0;
 
-    Pointilsynth::Oscillator oscillator_;
-    GrainEnvelope grainEnvelope_;
-    std::atomic<GrainSourceType> currentSourceType_ {GrainSourceType::Oscillator};
+  // Placeholder for the loaded audio file data.
+  juce::AudioBuffer<float> sourceAudio;
 
-    void triggerNewGrain();
+  Pointilsynth::Oscillator oscillator_;
+  GrainEnvelope grainEnvelope_;
+  std::atomic<GrainSourceType> currentSourceType_{GrainSourceType::Oscillator};
+
+  void triggerNewGrain();
 };

--- a/plugin/source/AudioEngine.cpp
+++ b/plugin/source/AudioEngine.cpp
@@ -1,6 +1,6 @@
 #include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_core/juce_core.h>  // For DBG, juce::File
-#include "PointilismInterfaces.h"
+#include "Pointilsynth/PointilismInterfaces.h"
 #include "Pointilsynth/ConfigManager.h"
 #include <vector>
 #include <algorithm>                 // Required for std::remove_if

--- a/plugin/source/AudioEngine.cpp
+++ b/plugin/source/AudioEngine.cpp
@@ -1,229 +1,248 @@
 #include <juce_audio_formats/juce_audio_formats.h>
-#include <juce_core/juce_core.h> // For DBG, juce::File
+#include <juce_core/juce_core.h>  // For DBG, juce::File
 #include "PointilismInterfaces.h"
+#include "Pointilsynth/ConfigManager.h"
 #include <vector>
-#include <algorithm> // Required for std::remove_if
-#include <cmath>     // For std::pow, std::cos, std::sin
-#include "Pointilsynth/Resampler.h" // For Resampler::getSample
+#include <algorithm>                 // Required for std::remove_if
+#include <cmath>                     // For std::pow, std::cos, std::sin
+#include "Pointilsynth/Resampler.h"  // For Resampler::getSample
 
+AudioEngine::AudioEngine(std::shared_ptr<ConfigManager> cfg)
+    : stochasticModel(std::move(cfg)), config_(std::move(cfg)) {}
 
-void AudioEngine::prepareToPlay(double sampleRate, int /*samplesPerBlock*/)
-{
-    currentSampleRate = sampleRate;
-    oscillator_.setSampleRate(sampleRate);
-    stochasticModel.setSampleRate(sampleRate); // Inform StochasticModel
-    samplesUntilNextGrain = stochasticModel.getSamplesUntilNextEvent();
-    grains.reserve(1024); // Keep existing functionality
+void AudioEngine::prepareToPlay(double sampleRate, int /*samplesPerBlock*/) {
+  currentSampleRate = sampleRate;
+  oscillator_.setSampleRate(sampleRate);
+  stochasticModel.setSampleRate(sampleRate);  // Inform StochasticModel
+  samplesUntilNextGrain = stochasticModel.getSamplesUntilNextEvent();
+  grains.reserve(1024);  // Keep existing functionality
 }
 
 // Add the following method:
-void AudioEngine::triggerNewGrain()
-{
-    Grain newGrain;
-    stochasticModel.generateNewGrain(newGrain); // Populate grain properties
+void AudioEngine::triggerNewGrain() {
+  Grain newGrain;
+  stochasticModel.generateNewGrain(newGrain);  // Populate grain properties
 
-    newGrain.id = grainIdCounter++; // Assign unique ID and increment counter
-    newGrain.isAlive = true;        // New grains are always initially alive
-    newGrain.ageInSamples = 0;      // New grains start with zero age
+  newGrain.id = grainIdCounter++;  // Assign unique ID and increment counter
+  newGrain.isAlive = true;         // New grains are always initially alive
+  newGrain.ageInSamples = 0;       // New grains start with zero age
 
-    // It's assumed that stochasticModel.generateNewGrain(newGrain) handles:
-    // - newGrain.pitch
-    // - newGrain.pan
-    // - newGrain.amplitude
-    // - newGrain.durationInSamples
-    // - newGrain.sourceSamplePosition (if applicable for the current source type)
+  // It's assumed that stochasticModel.generateNewGrain(newGrain) handles:
+  // - newGrain.pitch
+  // - newGrain.pan
+  // - newGrain.amplitude
+  // - newGrain.durationInSamples
+  // - newGrain.sourceSamplePosition (if applicable for the current source type)
 
-    grains.push_back(newGrain);
+  grains.push_back(newGrain);
 }
 
 // Add the following method:
-void AudioEngine::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /*midiMessages*/)
-{
-    const int numSamples = buffer.getNumSamples();
+void AudioEngine::processBlock(juce::AudioBuffer<float>& buffer,
+                               juce::MidiBuffer& /*midiMessages*/) {
+  const int numSamples = buffer.getNumSamples();
 
-    // Update the countdown for the next grain event
-    samplesUntilNextGrain -= numSamples;
+  // Update the countdown for the next grain event
+  samplesUntilNextGrain -= numSamples;
 
-    // Trigger new grains if the countdown has elapsed
-    while (samplesUntilNextGrain <= 0)
+  // Trigger new grains if the countdown has elapsed
+  while (samplesUntilNextGrain <= 0) {
+    triggerNewGrain();
+    // Add the full duration for the next event, plus any "overshoot" from the
+    // current block. This maintains more accurate timing for grain generation.
+    samplesUntilNextGrain += stochasticModel.getSamplesUntilNextEvent();
+    // Note: StochasticModel::getSamplesUntilNextEvent() must return a positive
+    // value to prevent potential infinite loops if it could return 0 or
+    // negative.
+  }
+
+  // Clear the buffer at the start of the block, after triggering new grains
+  buffer.clear();
+
+  // const int numSamples = buffer.getNumSamples(); // This line is already
+  // above the triggering logic
+
+  for (int s = 0; s < numSamples;
+       ++s)  // Outer loop: iterate through each sample in the block
+  {
+    float outputLeft = 0.0f;
+    float outputRight = 0.0f;
+
+    for (auto& grain : grains)  // Inner loop: iterate through each grain
     {
-        triggerNewGrain();
-        // Add the full duration for the next event, plus any "overshoot" from the current block.
-        // This maintains more accurate timing for grain generation.
-        samplesUntilNextGrain += stochasticModel.getSamplesUntilNextEvent();
-        // Note: StochasticModel::getSamplesUntilNextEvent() must return a positive value
-        // to prevent potential infinite loops if it could return 0 or negative.
+      if (!grain.isAlive)
+        continue;
+
+      // Check if grain's lifetime has just ended in this sample
+      if (grain.ageInSamples >= grain.durationInSamples) {
+        grain.isAlive = false;  // Mark for cleanup after the main sample loop
+        continue;
+      }
+
+      float sourceSample = 0.0f;
+
+      // A. Fetch source sample based on grain's source type
+      if (currentSourceType_.load() == GrainSourceType::Oscillator) {
+        double frequency = juce::MidiMessage::getMidiNoteInHertz(
+            static_cast<int>(std::round(grain.pitch)));
+        oscillator_.setFrequency(
+            static_cast<float>(frequency));  // Tune the shared oscillator
+        sourceSample =
+            oscillator_.getNextSample();  // Process and advance oscillator
+      } else if (currentSourceType_.load() == GrainSourceType::AudioSample) {
+        // Ensure sourceAudio is valid and has channels/samples
+        if (sourceAudio.getNumSamples() > 0 &&
+            sourceAudio.getNumChannels() > 0) {
+          int sourceChannelToRead =
+              0;  // Default to reading from channel 0
+                  // (Resampler expects a specific channel from source)
+          sourceSample = Resampler::getSample(sourceAudio, sourceChannelToRead,
+                                              grain.sourceSamplePosition);
+
+          // Advance grain's internal playback position for the audio sample,
+          // adjusted by pitch
+          float baseMidiNote = 60.0f;  // MIDI note 60 is normal speed
+          float pitchRatio =
+              std::pow(2.0f, (grain.pitch - baseMidiNote) / 12.0f);
+          grain.sourceSamplePosition += static_cast<double>(pitchRatio);
+
+          // Note: Resampler::getSample should handle grain.sourceSamplePosition
+          // going out of bounds.
+        }
+      }
+
+      // B. Calculate envelope value using GrainEnvelope
+      // grainEnvelope_ is a member of AudioEngine.
+      float envelopeValue = grainEnvelope_.getAmplitude(
+          grain.ageInSamples, grain.durationInSamples);
+
+      // C. Multiply source sample by envelope value and grain's overall
+      // amplitude
+      float processedSample = sourceSample * envelopeValue * grain.amplitude;
+
+      // D. Apply panning (Constant Power Panning)
+      float panPosition = grain.pan;  // Expected range: -1.0 (L) to 1.0 (R)
+      // Map pan position to an angle: -1.0 (L) -> 0, 0.0 (C) -> PI/4, 1.0 (R)
+      // -> PI/2
+      float panAngle =
+          (panPosition * 0.5f + 0.5f) * (juce::MathConstants<float>::pi * 0.5f);
+      float panGainLeft = std::cos(panAngle);
+      float panGainRight = std::sin(panAngle);
+
+      outputLeft += processedSample * panGainLeft;
+      outputRight += processedSample * panGainRight;
+
+      // E. Increment grain's ageInSamples (as it has been processed for one
+      // sample)
+      grain.ageInSamples++;
+    }  // End of inner grain loop
+
+    // Write accumulated stereo signal to the output buffer for the current
+    // sample 's'
+    if (buffer.getNumChannels() >
+        0) {  // Check if buffer has at least one channel
+      buffer.setSample(
+          0, s, outputLeft);  // Left channel (or mono if numChannels == 1)
+    }
+    if (buffer.getNumChannels() >
+        1) {  // Check if buffer has at least two channels
+      buffer.setSample(1, s, outputRight);  // Right channel
     }
 
-    // Clear the buffer at the start of the block, after triggering new grains
-    buffer.clear();
+    // Optional: Fill any additional channels (e.g., for surround sound setups)
+    for (int channel = 2; channel < buffer.getNumChannels(); ++channel) {
+      // Example: Mix down stereo to additional channels or set to zero
+      buffer.setSample(channel, s, (outputLeft + outputRight) * 0.5f);
+    }
+  }  // End of outer sample loop
 
-    // const int numSamples = buffer.getNumSamples(); // This line is already above the triggering logic
-
-    for (int s = 0; s < numSamples; ++s) // Outer loop: iterate through each sample in the block
-    {
-        float outputLeft = 0.0f;
-        float outputRight = 0.0f;
-
-        for (auto& grain : grains) // Inner loop: iterate through each grain
-        {
-            if (!grain.isAlive)
-                continue;
-
-            // Check if grain's lifetime has just ended in this sample
-            if (grain.ageInSamples >= grain.durationInSamples)
-            {
-                grain.isAlive = false; // Mark for cleanup after the main sample loop
-                continue;
-            }
-
-            float sourceSample = 0.0f;
-
-            // A. Fetch source sample based on grain's source type
-            if (currentSourceType_.load() == GrainSourceType::Oscillator)
-            {
-                double frequency = juce::MidiMessage::getMidiNoteInHertz(static_cast<int>(std::round(grain.pitch)));
-                oscillator_.setFrequency(static_cast<float>(frequency)); // Tune the shared oscillator
-                sourceSample = oscillator_.getNextSample(); // Process and advance oscillator
-            }
-            else if (currentSourceType_.load() == GrainSourceType::AudioSample)
-            {
-                // Ensure sourceAudio is valid and has channels/samples
-                if (sourceAudio.getNumSamples() > 0 && sourceAudio.getNumChannels() > 0)
-                {
-                    int sourceChannelToRead = 0; // Default to reading from channel 0
-                                                 // (Resampler expects a specific channel from source)
-                    sourceSample = Resampler::getSample(sourceAudio, sourceChannelToRead, grain.sourceSamplePosition);
-
-                    // Advance grain's internal playback position for the audio sample, adjusted by pitch
-                    float baseMidiNote = 60.0f; // MIDI note 60 is normal speed
-                    float pitchRatio = std::pow(2.0f, (grain.pitch - baseMidiNote) / 12.0f);
-                    grain.sourceSamplePosition += static_cast<double>(pitchRatio);
-
-                    // Note: Resampler::getSample should handle grain.sourceSamplePosition going out of bounds.
-                }
-            }
-
-            // B. Calculate envelope value using GrainEnvelope
-            // grainEnvelope_ is a member of AudioEngine.
-            float envelopeValue = grainEnvelope_.getAmplitude(grain.ageInSamples, grain.durationInSamples);
-
-            // C. Multiply source sample by envelope value and grain's overall amplitude
-            float processedSample = sourceSample * envelopeValue * grain.amplitude;
-
-            // D. Apply panning (Constant Power Panning)
-            float panPosition = grain.pan; // Expected range: -1.0 (L) to 1.0 (R)
-            // Map pan position to an angle: -1.0 (L) -> 0, 0.0 (C) -> PI/4, 1.0 (R) -> PI/2
-            float panAngle = (panPosition * 0.5f + 0.5f) * (juce::MathConstants<float>::pi * 0.5f);
-            float panGainLeft = std::cos(panAngle);
-            float panGainRight = std::sin(panAngle);
-
-            outputLeft += processedSample * panGainLeft;
-            outputRight += processedSample * panGainRight;
-
-            // E. Increment grain's ageInSamples (as it has been processed for one sample)
-            grain.ageInSamples++;
-        } // End of inner grain loop
-
-        // Write accumulated stereo signal to the output buffer for the current sample 's'
-        if (buffer.getNumChannels() > 0) { // Check if buffer has at least one channel
-            buffer.setSample(0, s, outputLeft);  // Left channel (or mono if numChannels == 1)
-        }
-        if (buffer.getNumChannels() > 1) { // Check if buffer has at least two channels
-            buffer.setSample(1, s, outputRight); // Right channel
-        }
-
-        // Optional: Fill any additional channels (e.g., for surround sound setups)
-        for (int channel = 2; channel < buffer.getNumChannels(); ++channel)
-        {
-            // Example: Mix down stereo to additional channels or set to zero
-            buffer.setSample(channel, s, (outputLeft + outputRight) * 0.5f);
-        }
-    } // End of outer sample loop
-
-    // Cleanup dead grains (this part remains from existing code)
-    grains.erase(
-        std::remove_if(grains.begin(), grains.end(), [](const Grain& grain) {
-            return !grain.isAlive;
-        }),
-        grains.end()
-    );
-} // End of processBlock
+  // Cleanup dead grains (this part remains from existing code)
+  grains.erase(
+      std::remove_if(grains.begin(), grains.end(),
+                     [](const Grain& grain) { return !grain.isAlive; }),
+      grains.end());
+}  // End of processBlock
 
 // Implementation of loadAudioSample - MOVED OUTSIDE processBlock
-void AudioEngine::loadAudioSample(const juce::File& audioFile)
-{
-    juce::AudioFormatManager formatManager;
-    formatManager.registerBasicFormats(); // Register WAV and AIFF
+void AudioEngine::loadAudioSample(const juce::File& audioFile) {
+  juce::AudioFormatManager formatManager;
+  formatManager.registerBasicFormats();  // Register WAV and AIFF
 
-    // Create a reader for the audio file
-    // Note: juce::AudioFormatReader is an abstract class, store as a pointer.
-    // Using std::unique_ptr for automatic memory management is a good practice.
-    std::unique_ptr<juce::AudioFormatReader> reader(formatManager.createReaderFor(audioFile));
+  // Create a reader for the audio file
+  // Note: juce::AudioFormatReader is an abstract class, store as a pointer.
+  // Using std::unique_ptr for automatic memory management is a good practice.
+  std::unique_ptr<juce::AudioFormatReader> reader(
+      formatManager.createReaderFor(audioFile));
 
-    if (reader == nullptr)
-    {
-        DBG("Error loading audio file: " + audioFile.getFullPathName());
-        // Optionally, clear the sourceAudio buffer or handle the error in a more specific way
-        sourceAudio.setSize(0, 0); // Clear buffer on error
-        return;
-    }
+  if (reader == nullptr) {
+    DBG("Error loading audio file: " + audioFile.getFullPathName());
+    // Optionally, clear the sourceAudio buffer or handle the error in a more
+    // specific way
+    sourceAudio.setSize(0, 0);  // Clear buffer on error
+    return;
+  }
 
-    // Resize the sourceAudio buffer to match the file's properties
-    // reader->numChannels gives the number of channels
-    // reader->lengthInSamples gives the total number of samples in the file
-    sourceAudio.setSize(static_cast<int>(reader->numChannels), static_cast<int>(reader->lengthInSamples));
+  // Resize the sourceAudio buffer to match the file's properties
+  // reader->numChannels gives the number of channels
+  // reader->lengthInSamples gives the total number of samples in the file
+  sourceAudio.setSize(static_cast<int>(reader->numChannels),
+                      static_cast<int>(reader->lengthInSamples));
 
-    // Read the audio data from the file into the sourceAudio buffer
-    // Parameters for reader->read:
-    // - targetBuffer: pointer to the buffer to fill (&sourceAudio)
-    // - startSampleInTargetBuffer: sample offset in the target buffer to start writing to (0)
-    // - numSamplesToRead: how many samples to read from the source (reader->lengthInSamples)
-    // - sourceSampleOffset: sample offset in the source file to start reading from (0)
-    // - fillLeftoversWithSilence: if true, fills remaining buffer with silence if source is shorter (true)
-    // - useStereoToMonoConversionIfNecessary: if true, converts stereo to mono if target is mono (true)
-    reader->read(
-        &sourceAudio,                               // Target buffer
-        0,                                          // Start sample in target buffer
-        static_cast<int>(reader->lengthInSamples),  // Number of samples to read
-        0,                                          // Start sample in source file
-        true,                                       // Fill leftovers with silence
-        true                                        // Use stereo to mono if necessary
-    );
+  // Read the audio data from the file into the sourceAudio buffer
+  // Parameters for reader->read:
+  // - targetBuffer: pointer to the buffer to fill (&sourceAudio)
+  // - startSampleInTargetBuffer: sample offset in the target buffer to start
+  // writing to (0)
+  // - numSamplesToRead: how many samples to read from the source
+  // (reader->lengthInSamples)
+  // - sourceSampleOffset: sample offset in the source file to start reading
+  // from (0)
+  // - fillLeftoversWithSilence: if true, fills remaining buffer with silence if
+  // source is shorter (true)
+  // - useStereoToMonoConversionIfNecessary: if true, converts stereo to mono if
+  // target is mono (true)
+  reader->read(
+      &sourceAudio,  // Target buffer
+      0,             // Start sample in target buffer
+      static_cast<int>(reader->lengthInSamples),  // Number of samples to read
+      0,                                          // Start sample in source file
+      true,                                       // Fill leftovers with silence
+      true  // Use stereo to mono if necessary
+  );
 
-    // The std::unique_ptr will automatically delete the reader when it goes out of scope.
-    // No need for `delete reader;` if using std::unique_ptr.
+  // The std::unique_ptr will automatically delete the reader when it goes out
+  // of scope. No need for `delete reader;` if using std::unique_ptr.
 
-    DBG("Loaded audio file: " + audioFile.getFullPathName() +
-        ", Channels: " + juce::String(sourceAudio.getNumChannels()) +
-        ", Samples: " + juce::String(sourceAudio.getNumSamples()));
+  DBG("Loaded audio file: " + audioFile.getFullPathName() +
+      ", Channels: " + juce::String(sourceAudio.getNumChannels()) +
+      ", Samples: " + juce::String(sourceAudio.getNumSamples()));
 }
 
-void AudioEngine::setGrainSource(int internalWaveformId)
-{
-    currentSourceType_.store(AudioEngine::GrainSourceType::Oscillator); // Set source type to Oscillator
+void AudioEngine::setGrainSource(int internalWaveformId) {
+  currentSourceType_.store(
+      AudioEngine::GrainSourceType::Oscillator);  // Set source type to
+                                                  // Oscillator
 
-    Pointilsynth::Oscillator::Waveform selectedWaveform;
+  Pointilsynth::Oscillator::Waveform selectedWaveform;
 
-    switch (internalWaveformId)
-    {
-        case 0:
-            selectedWaveform = Pointilsynth::Oscillator::Waveform::Sine;
-            break;
-        case 1:
-            selectedWaveform = Pointilsynth::Oscillator::Waveform::Saw;
-            break;
-        case 2:
-            selectedWaveform = Pointilsynth::Oscillator::Waveform::Square;
-            break;
-        case 3:
-            selectedWaveform = Pointilsynth::Oscillator::Waveform::Noise;
-            break;
-        default:
-            // Default to Sine for unrecognized IDs
-            selectedWaveform = Pointilsynth::Oscillator::Waveform::Sine;
-            // Consider adding DBG("Unknown internalWaveformId..."); for debugging
-            break;
-    }
-    oscillator_.setWaveform(selectedWaveform);
+  switch (internalWaveformId) {
+    case 0:
+      selectedWaveform = Pointilsynth::Oscillator::Waveform::Sine;
+      break;
+    case 1:
+      selectedWaveform = Pointilsynth::Oscillator::Waveform::Saw;
+      break;
+    case 2:
+      selectedWaveform = Pointilsynth::Oscillator::Waveform::Square;
+      break;
+    case 3:
+      selectedWaveform = Pointilsynth::Oscillator::Waveform::Noise;
+      break;
+    default:
+      // Default to Sine for unrecognized IDs
+      selectedWaveform = Pointilsynth::Oscillator::Waveform::Sine;
+      // Consider adding DBG("Unknown internalWaveformId..."); for debugging
+      break;
+  }
+  oscillator_.setWaveform(selectedWaveform);
 }

--- a/plugin/source/ConfigManager.cpp
+++ b/plugin/source/ConfigManager.cpp
@@ -1,0 +1,55 @@
+#include "Pointilsynth/ConfigManager.h"
+
+namespace {
+static std::shared_ptr<ConfigManager> instance;
+}
+
+std::shared_ptr<ConfigManager> ConfigManager::getInstance(
+    juce::AudioProcessor* processor) {
+  if (!instance && processor != nullptr)
+    instance = std::shared_ptr<ConfigManager>(new ConfigManager(processor));
+  else if (instance && processor != nullptr && instance->owner_ != processor)
+    instance = std::shared_ptr<ConfigManager>(new ConfigManager(processor));
+  return instance;
+}
+
+void ConfigManager::resetInstance() {
+  instance.reset();
+}
+
+juce::AudioProcessorValueTreeState& ConfigManager::getAPVTS() {
+  return apvts_;
+}
+
+void ConfigManager::addListener(const juce::String& paramID, Callback cb) {
+  auto listener = std::make_unique<FunctionListener>(std::move(cb));
+  apvts_.addParameterListener(paramID, listener.get());
+  listeners_[paramID].push_back(std::move(listener));
+}
+
+ConfigManager::ConfigManager(juce::AudioProcessor* processor)
+    : apvts_(*processor, nullptr, "PARAMETERS", createLayout()),
+      owner_(processor) {}
+
+juce::AudioProcessorValueTreeState::ParameterLayout
+ConfigManager::createLayout() {
+  std::vector<std::unique_ptr<juce::RangedAudioParameter>> params;
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      ParamID::pitch, "Pitch", 20.0f, 100.0f, 60.0f));
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      ParamID::dispersion, "Dispersion", 0.0f, 24.0f, 12.0f));
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      ParamID::avgDuration, "AvgDuration", 10.0f, 1000.0f, 200.0f));
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      ParamID::durationVariation, "DurationVariation", 0.0f, 1.0f, 0.25f));
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      ParamID::pan, "Pan", -1.0f, 1.0f, 0.0f));
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      ParamID::panSpread, "PanSpread", 0.0f, 1.0f, 0.5f));
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      ParamID::density, "Density", 0.1f, 50.0f, 10.0f));
+  params.push_back(std::make_unique<juce::AudioParameterChoice>(
+      ParamID::temporalDistribution, "TemporalDistribution",
+      juce::StringArray{"Uniform", "Poisson"}, 0));
+  return {params.begin(), params.end()};
+}

--- a/plugin/source/DebugUIPanel.cpp
+++ b/plugin/source/DebugUIPanel.cpp
@@ -1,202 +1,171 @@
 #include "DebugUIPanel.h"
-#include "PointilismInterfaces.h" // For StochasticModel::TemporalDistribution
+#include "PointilismInterfaces.h"  // For StochasticModel::TemporalDistribution
+#include "Pointilsynth/ConfigManager.h"
 
 // Constructor
-DebugUIPanel::DebugUIPanel(StochasticModel* model) : stochasticModel(model)
-{
-    // Initialize and configure sliders and labels
-    // Pitch
-    addAndMakeVisible(pitchSlider);
-    pitchSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-    pitchSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-    pitchSlider.setRange(20.0, 100.0, 0.1); // MIDI note numbers
-    if (stochasticModel) pitchSlider.setValue(static_cast<double>(stochasticModel->getPitch()), juce::dontSendNotification);
-    pitchSlider.onValueChange = [this] { pitchSliderChanged(); };
-    addAndMakeVisible(pitchLabel);
-    pitchLabel.setText("Pitch", juce::dontSendNotification);
-    pitchLabel.attachToComponent(&pitchSlider, true); // true for onLeft
+DebugUIPanel::DebugUIPanel(std::shared_ptr<ConfigManager> cfg)
+    : configManager(std::move(cfg)) {
+  // Initialize and configure sliders and labels
+  // Pitch
+  addAndMakeVisible(pitchSlider);
+  pitchSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+  pitchSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  pitchSlider.setRange(20.0, 100.0, 0.1);  // MIDI note numbers
+  if (configManager)
+    pitchAttachment = std::make_unique<SliderAttachment>(
+        configManager->getAPVTS(), ConfigManager::ParamID::pitch, pitchSlider);
+  addAndMakeVisible(pitchLabel);
+  pitchLabel.setText("Pitch", juce::dontSendNotification);
+  pitchLabel.attachToComponent(&pitchSlider, true);  // true for onLeft
 
-    // Dispersion
-    addAndMakeVisible(dispersionSlider);
-    dispersionSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-    dispersionSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-    dispersionSlider.setRange(0.0, 24.0, 0.1); // Semitones
-    if (stochasticModel) dispersionSlider.setValue(static_cast<double>(stochasticModel->getDispersion()), juce::dontSendNotification);
-    dispersionSlider.onValueChange = [this] { dispersionSliderChanged(); };
-    addAndMakeVisible(dispersionLabel);
-    dispersionLabel.setText("Dispersion", juce::dontSendNotification);
-    dispersionLabel.attachToComponent(&dispersionSlider, true);
+  // Dispersion
+  addAndMakeVisible(dispersionSlider);
+  dispersionSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+  dispersionSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  dispersionSlider.setRange(0.0, 24.0, 0.1);  // Semitones
+  if (configManager)
+    dispersionAttachment = std::make_unique<SliderAttachment>(
+        configManager->getAPVTS(), ConfigManager::ParamID::dispersion,
+        dispersionSlider);
+  addAndMakeVisible(dispersionLabel);
+  dispersionLabel.setText("Dispersion", juce::dontSendNotification);
+  dispersionLabel.attachToComponent(&dispersionSlider, true);
 
-    // Duration
-    addAndMakeVisible(durationSlider);
-    durationSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-    durationSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-    durationSlider.setRange(10.0, 1000.0, 1.0); // Milliseconds
-    if (stochasticModel) durationSlider.setValue(static_cast<double>(stochasticModel->getAverageDurationMs()), juce::dontSendNotification);
-    durationSlider.onValueChange = [this] { durationSliderChanged(); };
-    addAndMakeVisible(durationLabel);
-    durationLabel.setText("Duration (ms)", juce::dontSendNotification);
-    durationLabel.attachToComponent(&durationSlider, true);
+  // Duration
+  addAndMakeVisible(durationSlider);
+  durationSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+  durationSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  durationSlider.setRange(10.0, 1000.0, 1.0);  // Milliseconds
+  if (configManager)
+    durationAttachment = std::make_unique<SliderAttachment>(
+        configManager->getAPVTS(), ConfigManager::ParamID::avgDuration,
+        durationSlider);
+  addAndMakeVisible(durationLabel);
+  durationLabel.setText("Duration (ms)", juce::dontSendNotification);
+  durationLabel.attachToComponent(&durationSlider, true);
 
-    // Duration Variation
-    addAndMakeVisible(durationVariationSlider);
-    durationVariationSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-    durationVariationSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-    durationVariationSlider.setRange(0.0, 1.0, 0.01); // Percentage
-    if (stochasticModel) durationVariationSlider.setValue(static_cast<double>(stochasticModel->getDurationVariation()), juce::dontSendNotification);
-    durationVariationSlider.onValueChange = [this] { durationVariationSliderChanged(); };
-    addAndMakeVisible(durationVariationLabel);
-    durationVariationLabel.setText("Duration Var.", juce::dontSendNotification);
-    durationVariationLabel.attachToComponent(&durationVariationSlider, true);
+  // Duration Variation
+  addAndMakeVisible(durationVariationSlider);
+  durationVariationSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+  durationVariationSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80,
+                                          20);
+  durationVariationSlider.setRange(0.0, 1.0, 0.01);  // Percentage
+  if (configManager)
+    durationVariationAttachment = std::make_unique<SliderAttachment>(
+        configManager->getAPVTS(), ConfigManager::ParamID::durationVariation,
+        durationVariationSlider);
+  addAndMakeVisible(durationVariationLabel);
+  durationVariationLabel.setText("Duration Var.", juce::dontSendNotification);
+  durationVariationLabel.attachToComponent(&durationVariationSlider, true);
 
-    // Pan
-    addAndMakeVisible(panSlider);
-    panSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-    panSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-    panSlider.setRange(-1.0, 1.0, 0.01); // -1 (L) to 1 (R)
-    if (stochasticModel) panSlider.setValue(static_cast<double>(stochasticModel->getCentralPan()), juce::dontSendNotification);
-    panSlider.onValueChange = [this] { panSliderChanged(); };
-    addAndMakeVisible(panLabel);
-    panLabel.setText("Pan", juce::dontSendNotification);
-    panLabel.attachToComponent(&panSlider, true);
+  // Pan
+  addAndMakeVisible(panSlider);
+  panSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+  panSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  panSlider.setRange(-1.0, 1.0, 0.01);  // -1 (L) to 1 (R)
+  if (configManager)
+    panAttachment = std::make_unique<SliderAttachment>(
+        configManager->getAPVTS(), ConfigManager::ParamID::pan, panSlider);
+  addAndMakeVisible(panLabel);
+  panLabel.setText("Pan", juce::dontSendNotification);
+  panLabel.attachToComponent(&panSlider, true);
 
-    // Pan Spread
-    addAndMakeVisible(panSpreadSlider);
-    panSpreadSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-    panSpreadSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-    panSpreadSlider.setRange(0.0, 1.0, 0.01); // Spread amount
-    if (stochasticModel) panSpreadSlider.setValue(static_cast<double>(stochasticModel->getPanSpread()), juce::dontSendNotification);
-    panSpreadSlider.onValueChange = [this] { panSpreadSliderChanged(); };
-    addAndMakeVisible(panSpreadLabel);
-    panSpreadLabel.setText("Pan Spread", juce::dontSendNotification);
-    panSpreadLabel.attachToComponent(&panSpreadSlider, true);
+  // Pan Spread
+  addAndMakeVisible(panSpreadSlider);
+  panSpreadSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+  panSpreadSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  panSpreadSlider.setRange(0.0, 1.0, 0.01);  // Spread amount
+  if (configManager)
+    panSpreadAttachment = std::make_unique<SliderAttachment>(
+        configManager->getAPVTS(), ConfigManager::ParamID::panSpread,
+        panSpreadSlider);
+  addAndMakeVisible(panSpreadLabel);
+  panSpreadLabel.setText("Pan Spread", juce::dontSendNotification);
+  panSpreadLabel.attachToComponent(&panSpreadSlider, true);
 
-    // Density
-    addAndMakeVisible(densitySlider);
-    densitySlider.setSliderStyle(juce::Slider::LinearHorizontal);
-    densitySlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-    densitySlider.setRange(0.1, 50.0, 0.1); // Grains per second
-    if (stochasticModel) densitySlider.setValue(static_cast<double>(stochasticModel->getGlobalDensity()), juce::dontSendNotification);
-    densitySlider.onValueChange = [this] { densitySliderChanged(); };
-    addAndMakeVisible(densityLabel);
-    densityLabel.setText("Density (gr/s)", juce::dontSendNotification);
-    densityLabel.attachToComponent(&densitySlider, true);
+  // Density
+  addAndMakeVisible(densitySlider);
+  densitySlider.setSliderStyle(juce::Slider::LinearHorizontal);
+  densitySlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  densitySlider.setRange(0.1, 50.0, 0.1);  // Grains per second
+  if (configManager)
+    densityAttachment = std::make_unique<SliderAttachment>(
+        configManager->getAPVTS(), ConfigManager::ParamID::density,
+        densitySlider);
+  addAndMakeVisible(densityLabel);
+  densityLabel.setText("Density (gr/s)", juce::dontSendNotification);
+  densityLabel.attachToComponent(&densitySlider, true);
 
-    // Temporal Distribution
-    addAndMakeVisible(temporalDistributionComboBox);
-    temporalDistributionComboBox.addItem("Uniform", static_cast<int>(StochasticModel::TemporalDistribution::Uniform) + 1);
-    temporalDistributionComboBox.addItem("Poisson", static_cast<int>(StochasticModel::TemporalDistribution::Poisson) + 1);
-    if (stochasticModel) temporalDistributionComboBox.setSelectedId(static_cast<int>(stochasticModel->getGlobalTemporalDistribution()) + 1, juce::dontSendNotification);
-    temporalDistributionComboBox.onChange = [this] { temporalDistributionChanged(); };
-    addAndMakeVisible(temporalDistributionLabel);
-    temporalDistributionLabel.setText("Distribution", juce::dontSendNotification);
-    temporalDistributionLabel.attachToComponent(&temporalDistributionComboBox, true);
+  // Temporal Distribution
+  addAndMakeVisible(temporalDistributionComboBox);
+  temporalDistributionComboBox.addItem(
+      "Uniform",
+      static_cast<int>(StochasticModel::TemporalDistribution::Uniform) + 1);
+  temporalDistributionComboBox.addItem(
+      "Poisson",
+      static_cast<int>(StochasticModel::TemporalDistribution::Poisson) + 1);
+  if (configManager)
+    temporalDistributionAttachment = std::make_unique<ComboBoxAttachment>(
+        configManager->getAPVTS(), ConfigManager::ParamID::temporalDistribution,
+        temporalDistributionComboBox);
+  addAndMakeVisible(temporalDistributionLabel);
+  temporalDistributionLabel.setText("Distribution", juce::dontSendNotification);
+  temporalDistributionLabel.attachToComponent(&temporalDistributionComboBox,
+                                              true);
 
-    // The editor is responsible for setting our size.
-    // setSize(600, 400); // This was set by PluginEditor
+  // The editor is responsible for setting our size.
+  // setSize(600, 400); // This was set by PluginEditor
 }
 
-DebugUIPanel::~DebugUIPanel()
-{
-    // Destructor (JUCE handles cleanup of child components as they are owned)
-    // Listeners are lambda based and managed by JUCE Slider/ComboBox, no manual removal needed.
+DebugUIPanel::~DebugUIPanel() {
+  // Destructor (JUCE handles cleanup of child components as they are owned)
+  // Listeners are lambda based and managed by JUCE Slider/ComboBox, no manual
+  // removal needed.
 }
 
-void DebugUIPanel::paint(juce::Graphics& g)
-{
-    // Fill the background
-    g.fillAll(getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
+void DebugUIPanel::paint(juce::Graphics& g) {
+  // Fill the background
+  g.fillAll(
+      getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
 }
 
-void DebugUIPanel::resized()
-{
-    juce::FlexBox fb;
-    fb.flexDirection = juce::FlexBox::Direction::column;
-    fb.alignItems = juce::FlexBox::AlignItems::stretch; // Components will stretch to width
-    fb.justifyContent = juce::FlexBox::JustifyContent::flexStart;
+void DebugUIPanel::resized() {
+  juce::FlexBox fb;
+  fb.flexDirection = juce::FlexBox::Direction::column;
+  fb.alignItems =
+      juce::FlexBox::AlignItems::stretch;  // Components will stretch to width
+  fb.justifyContent = juce::FlexBox::JustifyContent::flexStart;
 
-    // Helper to add item with margin and fixed height
-    auto addItemToFlexBox = [&](juce::Component& comp, float height) {
-        // Labels are attached to the left, so they don't need separate FlexItems if they size themselves.
-        // The component itself (slider/combobox) takes the full width.
-        fb.items.add(juce::FlexItem(comp).withHeight(height).withMargin(juce::FlexItem::Margin(2.0f, 0, 2.0f, 0))); // Top/Bottom margin
-    };
+  // Helper to add item with margin and fixed height
+  auto addItemToFlexBox = [&](juce::Component& comp, float height) {
+    // Labels are attached to the left, so they don't need separate FlexItems if
+    // they size themselves. The component itself (slider/combobox) takes the
+    // full width.
+    fb.items.add(juce::FlexItem(comp).withHeight(height).withMargin(
+        juce::FlexItem::Margin(2.0f, 0, 2.0f, 0)));  // Top/Bottom margin
+  };
 
-    float standardItemHeight = 25.0f; // Standard height for sliders and combobox
+  float standardItemHeight = 25.0f;  // Standard height for sliders and combobox
 
-    // Labels are attached to the left of these components.
-    // Their width is set by label.attachToComponent or can be set explicitly if needed.
-    // For attached labels, their width is managed by JUCE.
-    // We can set a common width for labels if desired:
-    // pitchLabel.setMinimumHorizontalScale(0.8f); // Example
-    // Or ensure labels have enough text space.
-    // For attached labels, their width is part of the component they are attached to.
-    // The FlexBox will lay out the main components (sliders, combobox).
+  // Labels are attached to the left of these components.
+  // Their width is set by label.attachToComponent or can be set explicitly if
+  // needed. For attached labels, their width is managed by JUCE. We can set a
+  // common width for labels if desired:
+  // pitchLabel.setMinimumHorizontalScale(0.8f); // Example
+  // Or ensure labels have enough text space.
+  // For attached labels, their width is part of the component they are attached
+  // to. The FlexBox will lay out the main components (sliders, combobox).
 
-    addItemToFlexBox(pitchSlider, standardItemHeight);
-    addItemToFlexBox(dispersionSlider, standardItemHeight);
-    addItemToFlexBox(durationSlider, standardItemHeight);
-    addItemToFlexBox(durationVariationSlider, standardItemHeight);
-    addItemToFlexBox(panSlider, standardItemHeight);
-    addItemToFlexBox(panSpreadSlider, standardItemHeight);
-    addItemToFlexBox(densitySlider, standardItemHeight);
-    addItemToFlexBox(temporalDistributionComboBox, standardItemHeight);
+  addItemToFlexBox(pitchSlider, standardItemHeight);
+  addItemToFlexBox(dispersionSlider, standardItemHeight);
+  addItemToFlexBox(durationSlider, standardItemHeight);
+  addItemToFlexBox(durationVariationSlider, standardItemHeight);
+  addItemToFlexBox(panSlider, standardItemHeight);
+  addItemToFlexBox(panSpreadSlider, standardItemHeight);
+  addItemToFlexBox(densitySlider, standardItemHeight);
+  addItemToFlexBox(temporalDistributionComboBox, standardItemHeight);
 
-    // Perform layout within the panel's bounds, reduced by a margin for aesthetics
-    fb.performLayout(getLocalBounds().reduced(10));
-}
-
-// Callback methods
-void DebugUIPanel::pitchSliderChanged()
-{
-    if (stochasticModel)
-        stochasticModel->setPitchAndDispersion(static_cast<float>(pitchSlider.getValue()), static_cast<float>(dispersionSlider.getValue()));
-}
-
-void DebugUIPanel::dispersionSliderChanged()
-{
-    if (stochasticModel)
-        stochasticModel->setPitchAndDispersion(static_cast<float>(pitchSlider.getValue()), static_cast<float>(dispersionSlider.getValue()));
-}
-
-void DebugUIPanel::durationSliderChanged()
-{
-    if (stochasticModel)
-        stochasticModel->setDurationAndVariation(static_cast<float>(durationSlider.getValue()), static_cast<float>(durationVariationSlider.getValue()));
-}
-
-void DebugUIPanel::durationVariationSliderChanged()
-{
-    if (stochasticModel)
-        stochasticModel->setDurationAndVariation(static_cast<float>(durationSlider.getValue()), static_cast<float>(durationVariationSlider.getValue()));
-}
-
-void DebugUIPanel::panSliderChanged()
-{
-    if (stochasticModel)
-        stochasticModel->setPanAndSpread(static_cast<float>(panSlider.getValue()), static_cast<float>(panSpreadSlider.getValue()));
-}
-
-void DebugUIPanel::panSpreadSliderChanged()
-{
-    if (stochasticModel)
-        stochasticModel->setPanAndSpread(static_cast<float>(panSlider.getValue()), static_cast<float>(panSpreadSlider.getValue()));
-}
-
-void DebugUIPanel::densitySliderChanged()
-{
-    if (stochasticModel)
-        stochasticModel->setGlobalDensity(static_cast<float>(densitySlider.getValue()));
-}
-
-void DebugUIPanel::temporalDistributionChanged()
-{
-    if (stochasticModel)
-    {
-        int selectedId = temporalDistributionComboBox.getSelectedId();
-        // Enum values are 0-indexed, ComboBox IDs are 1-indexed
-        if (selectedId > 0) {
-             stochasticModel->setGlobalTemporalDistribution(static_cast<StochasticModel::TemporalDistribution>(selectedId - 1));
-        }
-    }
+  // Perform layout within the panel's bounds, reduced by a margin for
+  // aesthetics
+  fb.performLayout(getLocalBounds().reduced(10));
 }

--- a/plugin/source/DebugUIPanel.cpp
+++ b/plugin/source/DebugUIPanel.cpp
@@ -1,5 +1,5 @@
-#include "DebugUIPanel.h"
-#include "PointilismInterfaces.h"  // For StochasticModel::TemporalDistribution
+#include "Pointilsynth/DebugUIPanel.h"
+#include "Pointilsynth/PointilismInterfaces.h"  // For StochasticModel::TemporalDistribution
 #include "Pointilsynth/ConfigManager.h"
 
 // Constructor

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -1,5 +1,6 @@
 #include "Pointilsynth/PluginEditor.h"
 #include "Pointilsynth/PluginProcessor.h"  // Ensure this path is correct based on include directories
+#include "Pointilsynth/ConfigManager.h"
 
 namespace audio_plugin {
 
@@ -7,7 +8,7 @@ PointillisticSynthAudioProcessorEditor::PointillisticSynthAudioProcessorEditor(
     audio_plugin::AudioPluginAudioProcessor& p)
     : juce::AudioProcessorEditor(&p),
       processorRef(p),
-      debugUIPanel(processorRef.getStochasticModel()) {
+      debugUIPanel(processorRef.getConfigManager()) {
   addAndMakeVisible(pitchPod);
   addAndMakeVisible(densityPod);
   addAndMakeVisible(durationPod);

--- a/plugin/source/PluginProcessor.cpp
+++ b/plugin/source/PluginProcessor.cpp
@@ -1,6 +1,7 @@
 #include "Pointilsynth/ProjectInfo.h"
 #include "Pointilsynth/PluginProcessor.h"
 #include "Pointilsynth/PluginEditor.h"
+#include "Pointilsynth/ConfigManager.h"
 
 namespace audio_plugin {
 AudioPluginAudioProcessor::AudioPluginAudioProcessor()
@@ -12,10 +13,14 @@ AudioPluginAudioProcessor::AudioPluginAudioProcessor()
 #endif
               .withOutput("Output", juce::AudioChannelSet::stereo(), true)
 #endif
-      ) {
+              ),
+      configManager(ConfigManager::getInstance(this)),
+      audioEngine(configManager) {
 }
 
-AudioPluginAudioProcessor::~AudioPluginAudioProcessor() {}
+AudioPluginAudioProcessor::~AudioPluginAudioProcessor() {
+  ConfigManager::resetInstance();
+}
 
 const juce::String AudioPluginAudioProcessor::getName() const {
   return ProjectInfo::projectName;
@@ -77,7 +82,8 @@ void AudioPluginAudioProcessor::prepareToPlay(double sampleRate,
                                               int samplesPerBlock) {
   // Use this method as the place to do any pre-playback
   // initialisation that you need..
-  // juce::ignoreUnused(sampleRate, samplesPerBlock); // Removed by audioEngine call
+  // juce::ignoreUnused(sampleRate, samplesPerBlock); // Removed by audioEngine
+  // call
   audioEngine.prepareToPlay(sampleRate, samplesPerBlock);
 }
 
@@ -134,7 +140,8 @@ void AudioPluginAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer,
   // the samples and the outer loop is handling the channels.
   // Alternatively, you can process the samples with the channels
   // interleaved by keeping the same state.
-  // for (int channel = 0; channel < totalNumInputChannels; ++channel) { // Removed by audioEngine call
+  // for (int channel = 0; channel < totalNumInputChannels; ++channel) { //
+  // Removed by audioEngine call
   //   auto* channelData = buffer.getWritePointer(channel);
   //   juce::ignoreUnused(channelData);
   //   // ..do something to the data...

--- a/plugin/source/PresetManager.cpp
+++ b/plugin/source/PresetManager.cpp
@@ -1,4 +1,5 @@
 #include "Pointilsynth/PresetManager.h"
+#include "Pointilsynth/ConfigManager.h"
 #include "juce_core/juce_core.h"  // For juce::File
 #include "nlohmann/json.hpp"      // For nlohmann::json
 

--- a/plugin/source/StochasticModel.cpp
+++ b/plugin/source/StochasticModel.cpp
@@ -1,4 +1,4 @@
-#include "PointilismInterfaces.h"  // Assuming this is the correct path relative to the cpp file
+#include "Pointilsynth/PointilismInterfaces.h"  // Assuming this is the correct path relative to the cpp file
 #include "Pointilsynth/ConfigManager.h"
 #include <random>  // For distributions if needed directly in setters, though likely just for storage here
 #include <cmath>   // For std::abs, std::max etc. if needed

--- a/plugin/source/StochasticModel.cpp
+++ b/plugin/source/StochasticModel.cpp
@@ -1,121 +1,151 @@
-#include "PointilismInterfaces.h" // Assuming this is the correct path relative to the cpp file
-#include <random> // For distributions if needed directly in setters, though likely just for storage here
-#include <cmath>  // For std::abs, std::max etc. if needed
-#include <limits> // For std::numeric_limits<double>::epsilon(), INT_MAX
-#include <algorithm> // Will be needed for std::clamp in other methods
+#include "PointilismInterfaces.h"  // Assuming this is the correct path relative to the cpp file
+#include "Pointilsynth/ConfigManager.h"
+#include <random>  // For distributions if needed directly in setters, though likely just for storage here
+#include <cmath>   // For std::abs, std::max etc. if needed
+#include <limits>  // For std::numeric_limits<double>::epsilon(), INT_MAX
+#include <algorithm>  // Will be needed for std::clamp in other methods
+
+StochasticModel::StochasticModel(std::shared_ptr<ConfigManager> cfg)
+    : config_(std::move(cfg)) {
+  if (config_) {
+    config_->addListener(ConfigManager::ParamID::pitch,
+                         [this](float v) { pitch = v; });
+    config_->addListener(ConfigManager::ParamID::dispersion,
+                         [this](float v) { dispersion = v; });
+    config_->addListener(ConfigManager::ParamID::avgDuration,
+                         [this](float v) { averageDurationMs_ = v; });
+    config_->addListener(ConfigManager::ParamID::durationVariation,
+                         [this](float v) { durationVariation_ = v; });
+    config_->addListener(ConfigManager::ParamID::pan,
+                         [this](float v) { centralPan = v; });
+    config_->addListener(ConfigManager::ParamID::panSpread,
+                         [this](float v) { panSpread = v; });
+    config_->addListener(ConfigManager::ParamID::density,
+                         [this](float v) { globalDensity_ = v; });
+    config_->addListener(
+        ConfigManager::ParamID::temporalDistribution, [this](float v) {
+          globalTemporalDistribution_ =
+              static_cast<TemporalDistribution>(static_cast<int>(v));
+        });
+  }
+}
 
 // Forward declaration or ensure StochasticModel is fully defined via header
-// class StochasticModel; // Not needed if PointilismInterfaces.h includes full definition
+// class StochasticModel; // Not needed if PointilismInterfaces.h includes full
+// definition
 
-void StochasticModel::setDurationAndVariation(float averageDurationMs, float variation)
-{
-    averageDurationMs_ = averageDurationMs;
-    durationVariation_ = variation;
+void StochasticModel::setDurationAndVariation(float averageDurationMs,
+                                              float variation) {
+  averageDurationMs_ = averageDurationMs;
+  durationVariation_ = variation;
 }
 
-void StochasticModel::setSampleRate(double newSampleRate)
-{
-    sampleRate_ = newSampleRate;
+void StochasticModel::setSampleRate(double newSampleRate) {
+  sampleRate_ = newSampleRate;
 }
 
-void StochasticModel::generateNewGrain(Grain& newGrain)
-{
-    // 1. Get atomic values
-    float avgDurationMs = averageDurationMs_.load(std::memory_order_relaxed);
-    float variation = durationVariation_.load(std::memory_order_relaxed); // This is the 'variation' parameter, e.g., 0.1 for 10%
-    double currentSampleRate = sampleRate_.load(std::memory_order_relaxed);
+void StochasticModel::generateNewGrain(Grain& newGrain) {
+  // 1. Get atomic values
+  float avgDurationMs = averageDurationMs_.load(std::memory_order_relaxed);
+  float variation = durationVariation_.load(
+      std::memory_order_relaxed);  // This is the 'variation' parameter, e.g.,
+                                   // 0.1 for 10%
+  double currentSampleRate = sampleRate_.load(std::memory_order_relaxed);
 
-    // 2. Calculate randomized duration factor
-    // uniformRealDistribution_ is [-0.5f, 0.5f].
-    // randomPercentDeviation will be in range [-variation, +variation]
-    // e.g. if variation = 0.1, then randomPercentDeviation is in [-0.1, 0.1]
-    float randomPercentDeviation = uniformRealDistribution_(randomEngine) * 2.0f * variation;
+  // 2. Calculate randomized duration factor
+  // uniformRealDistribution_ is [-0.5f, 0.5f].
+  // randomPercentDeviation will be in range [-variation, +variation]
+  // e.g. if variation = 0.1, then randomPercentDeviation is in [-0.1, 0.1]
+  float randomPercentDeviation =
+      uniformRealDistribution_(randomEngine) * 2.0f * variation;
 
-    // 3. Randomized duration in ms
-    float randomizedDurationMs = avgDurationMs * (1.0f + randomPercentDeviation);
+  // 3. Randomized duration in ms
+  float randomizedDurationMs = avgDurationMs * (1.0f + randomPercentDeviation);
 
-    // 4. Ensure duration is not negative
-    randomizedDurationMs = std::max(0.0f, randomizedDurationMs);
+  // 4. Ensure duration is not negative
+  randomizedDurationMs = std::max(0.0f, randomizedDurationMs);
 
-    // 5. Convert to samples
-    // Ensure sampleRate is not zero to prevent division by zero or NaN issues.
-    if (currentSampleRate <= 0) {
-        // Fallback to a default sample rate, or log an error.
-        // For now, using a common default.
-        currentSampleRate = 44100.0;
-    }
-    newGrain.durationInSamples = static_cast<int>((static_cast<double>(randomizedDurationMs) / 1000.0) * currentSampleRate);
+  // 5. Convert to samples
+  // Ensure sampleRate is not zero to prevent division by zero or NaN issues.
+  if (currentSampleRate <= 0) {
+    // Fallback to a default sample rate, or log an error.
+    // For now, using a common default.
+    currentSampleRate = 44100.0;
+  }
+  newGrain.durationInSamples = static_cast<int>(
+      (static_cast<double>(randomizedDurationMs) / 1000.0) * currentSampleRate);
 
-    // Other members of Grain (pitch, pan, amplitude, etc.) are not set here
-    // as per the current task. They would be set by other parts of StochasticModel
-    // or have default values.
-      // Pitch
-    using PitchDistributionParams = std::normal_distribution<float>::param_type;
-    pitchDistribution.param(PitchDistributionParams(pitch.load(), dispersion.load()));
-    newGrain.pitch = pitchDistribution(randomEngine);
+  // Other members of Grain (pitch, pan, amplitude, etc.) are not set here
+  // as per the current task. They would be set by other parts of
+  // StochasticModel or have default values. Pitch
+  using PitchDistributionParams = std::normal_distribution<float>::param_type;
+  pitchDistribution.param(
+      PitchDistributionParams(pitch.load(), dispersion.load()));
+  newGrain.pitch = pitchDistribution(randomEngine);
 
-    // Pan
-    using PanDistributionParams = std::normal_distribution<float>::param_type;
-    panDistribution.param(PanDistributionParams(centralPan.load(), panSpread.load()));
-    float generatedPan = panDistribution(randomEngine);
-    newGrain.pan = std::clamp(generatedPan, -1.0f, 1.0f);
+  // Pan
+  using PanDistributionParams = std::normal_distribution<float>::param_type;
+  panDistribution.param(
+      PanDistributionParams(centralPan.load(), panSpread.load()));
+  float generatedPan = panDistribution(randomEngine);
+  newGrain.pan = std::clamp(generatedPan, -1.0f, 1.0f);
 
-    // Other grain properties will be set elsewhere or in future tasks.
-    // For now, ensure isAlive is true and assign a temporary ID or leave as default.
-    newGrain.isAlive = true;
-    // newGrain.id = ...; // Not part of this task's core requirements for pitch/pan
-    // newGrain.amplitude = ...;
-    // newGrain.durationInSamples = ...;
-    // newGrain.ageInSamples = 0;
-    // newGrain.sourceSamplePosition = ...;
+  // Other grain properties will be set elsewhere or in future tasks.
+  // For now, ensure isAlive is true and assign a temporary ID or leave as
+  // default.
+  newGrain.isAlive = true;
+  // newGrain.id = ...; // Not part of this task's core requirements for
+  // pitch/pan newGrain.amplitude = ...; newGrain.durationInSamples = ...;
+  // newGrain.ageInSamples = 0;
+  // newGrain.sourceSamplePosition = ...;
 }
 
-int StochasticModel::getSamplesUntilNextEvent()
-{
-    // 1. Get atomic values
-    float currentGrainsPerSecond = globalDensity_.load(std::memory_order_relaxed);
-    double currentSampleRate = sampleRate_.load(std::memory_order_relaxed);
-    TemporalDistribution currentModel = globalTemporalDistribution_.load(std::memory_order_relaxed);
+int StochasticModel::getSamplesUntilNextEvent() {
+  // 1. Get atomic values
+  float currentGrainsPerSecond = globalDensity_.load(std::memory_order_relaxed);
+  double currentSampleRate = sampleRate_.load(std::memory_order_relaxed);
+  TemporalDistribution currentModel =
+      globalTemporalDistribution_.load(std::memory_order_relaxed);
 
-    // 2. Validate inputs and calculate average samples per grain
-    if (currentGrainsPerSecond <= 0.0f || currentSampleRate <= 0.0)
-    {
-        // Cannot compute a meaningful event interval, return a very large number of samples
-        // to effectively pause event generation.
-        return INT_MAX;
-    }
-
-    double averageSamplesPerGrain = currentSampleRate / static_cast<double>(currentGrainsPerSecond);
-
-    // Check for potential issues with averageSamplesPerGrain before using it,
-    // especially with the Poisson distribution.
-    if (averageSamplesPerGrain <= 0.0 || std::isinf(averageSamplesPerGrain) || std::isnan(averageSamplesPerGrain)) {
-        return INT_MAX; // Not a valid mean for Poisson or for timing.
-    }
-
-
-    // 3. Handle TemporalDistribution models
-    if (currentModel == TemporalDistribution::Uniform)
-    {
-        return static_cast<int>(averageSamplesPerGrain);
-    }
-    else if (currentModel == TemporalDistribution::Poisson)
-    {
-        // Ensure the mean for the Poisson distribution is positive.
-        // Clamping to a very small positive number if averageSamplesPerGrain is too small,
-        // as Poisson distribution mean must be > 0.
-        double poissonMean = std::max(std::numeric_limits<double>::epsilon(), averageSamplesPerGrain);
-
-        // Update the Poisson distribution's mean parameter.
-        // This is technically not thread-safe if multiple threads call this concurrently
-        // AND randomEngine is shared without locks. However, randomEngine itself is not thread-safe by default.
-        // Assuming single audio thread access for generation, or external synchronization for randomEngine if shared.
-        // For typical JUCE audio processing, this method and generateNewGrain would be called from the same audio thread.
-        poissonDistribution_.param(std::poisson_distribution<int>::param_type(poissonMean));
-        return poissonDistribution_(randomEngine);
-    }
-
-    // Fallback, though ideally all enum values should be handled.
+  // 2. Validate inputs and calculate average samples per grain
+  if (currentGrainsPerSecond <= 0.0f || currentSampleRate <= 0.0) {
+    // Cannot compute a meaningful event interval, return a very large number of
+    // samples to effectively pause event generation.
     return INT_MAX;
+  }
 
+  double averageSamplesPerGrain =
+      currentSampleRate / static_cast<double>(currentGrainsPerSecond);
+
+  // Check for potential issues with averageSamplesPerGrain before using it,
+  // especially with the Poisson distribution.
+  if (averageSamplesPerGrain <= 0.0 || std::isinf(averageSamplesPerGrain) ||
+      std::isnan(averageSamplesPerGrain)) {
+    return INT_MAX;  // Not a valid mean for Poisson or for timing.
+  }
+
+  // 3. Handle TemporalDistribution models
+  if (currentModel == TemporalDistribution::Uniform) {
+    return static_cast<int>(averageSamplesPerGrain);
+  } else if (currentModel == TemporalDistribution::Poisson) {
+    // Ensure the mean for the Poisson distribution is positive.
+    // Clamping to a very small positive number if averageSamplesPerGrain is too
+    // small, as Poisson distribution mean must be > 0.
+    double poissonMean = std::max(std::numeric_limits<double>::epsilon(),
+                                  averageSamplesPerGrain);
+
+    // Update the Poisson distribution's mean parameter.
+    // This is technically not thread-safe if multiple threads call this
+    // concurrently AND randomEngine is shared without locks. However,
+    // randomEngine itself is not thread-safe by default. Assuming single audio
+    // thread access for generation, or external synchronization for
+    // randomEngine if shared. For typical JUCE audio processing, this method
+    // and generateNewGrain would be called from the same audio thread.
+    poissonDistribution_.param(
+        std::poisson_distribution<int>::param_type(poissonMean));
+    return poissonDistribution_(randomEngine);
+  }
+
+  // Fallback, though ideally all enum values should be handled.
+  return INT_MAX;
 }

--- a/test/source/DebugUIPanelTest.cpp
+++ b/test/source/DebugUIPanelTest.cpp
@@ -1,10 +1,12 @@
 #include "Pointilsynth/DebugUIPanel.h"
-#include "Pointilsynth/PointilismInterfaces.h" // For StochasticModel
+#include "Pointilsynth/PluginProcessor.h"
+#include "Pointilsynth/ConfigManager.h"
 #include <gtest/gtest.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
 TEST(DebugUIPanelTest, CanConstruct) {
-    juce::ScopedJuceInitialiser_GUI libraryInitialiser;
-    StochasticModel model;
-    EXPECT_NO_THROW(std::make_unique<DebugUIPanel>(&model));
+  juce::ScopedJuceInitialiser_GUI libraryInitialiser;
+  audio_plugin::AudioPluginAudioProcessor processor;
+  auto cfg = ConfigManager::getInstance(&processor);
+  EXPECT_NO_THROW(std::make_unique<DebugUIPanel>(cfg));
 }


### PR DESCRIPTION
## Summary
- add ConfigManager built on `AudioProcessorValueTreeState`
- wire StochasticModel and AudioEngine to use ConfigManager
- update processor, editor, and debug UI to share the manager
- adjust tests for new API
- fix destruction order of DebugUIPanel attachments
- reset ConfigManager when processor is destroyed

## Testing
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`


------
https://chatgpt.com/codex/tasks/task_e_684f9fa1d1a08323aa1ca96370e22721