### PR TITLE
Add PresetBrowserComponent

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SOURCE_FILES
     source/PluginProcessor.cpp
     source/PluginEditor.cpp
     source/PresetManager.cpp
+    source/UI/PresetBrowserComponent.cpp
     source/StochasticModel.cpp
 )
 # Optional; includes header files in the project file tree in Visual Studio
@@ -61,6 +62,7 @@ set(HEADER_FILES
     ${INCLUDE_DIR}/PointilismInterfaces.h
     ${INCLUDE_DIR}/PresetManager.h
     ${INCLUDE_DIR}/Resampler.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/UI/PresetBrowserComponent.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/PodComponent.h
 )
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCE_FILES} ${HEADER_FILES})

--- a/plugin/include/UI/PresetBrowserComponent.h
+++ b/plugin/include/UI/PresetBrowserComponent.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "Pointilsynth/PresetManager.h"
+
+namespace audio_plugin {
+
+class PresetBrowserComponent : public juce::Component,
+                               private juce::ListBoxModel {
+public:
+  explicit PresetBrowserComponent(Pointilism::PresetManager& manager);
+  ~PresetBrowserComponent() override = default;
+
+  void paint(juce::Graphics& g) override;
+  void resized() override;
+
+  int getNumRows() override;
+  void paintListBoxItem(int rowNumber,
+                        juce::Graphics& g,
+                        int width,
+                        int height,
+                        bool rowIsSelected) override;
+
+private:
+  struct PresetEntry {
+    juce::File file;
+    juce::String category;
+  };
+
+  void scanPresetDirectory();
+  void loadSelectedPreset();
+  void savePreset();
+
+  Pointilism::PresetManager& presetManager;
+
+  juce::ListBox presetList;
+  juce::TextButton loadButton{"Load"};
+  juce::TextButton saveButton{"Save"};
+  juce::TextEditor presetNameEditor;
+  juce::ComboBox categoryCombo;
+
+  juce::File presetDirectory;
+  std::vector<PresetEntry> presets;
+
+  JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PresetBrowserComponent)
+};
+
+}  // namespace audio_plugin

--- a/plugin/source/UI/PresetBrowserComponent.cpp
+++ b/plugin/source/UI/PresetBrowserComponent.cpp
@@ -1,0 +1,129 @@
+#include "UI/PresetBrowserComponent.h"
+#include "nlohmann/json.hpp"
+
+namespace audio_plugin {
+
+PresetBrowserComponent::PresetBrowserComponent(
+    Pointilism::PresetManager& manager)
+    : presetManager(manager) {
+  addAndMakeVisible(presetList);
+  presetList.setModel(this);
+
+  addAndMakeVisible(loadButton);
+  addAndMakeVisible(saveButton);
+  addAndMakeVisible(presetNameEditor);
+  addAndMakeVisible(categoryCombo);
+
+  categoryCombo.addItem("All", 1);
+  categoryCombo.addItem("Texture", 2);
+  categoryCombo.addItem("Rhythmic", 3);
+  categoryCombo.addItem("FX", 4);
+  categoryCombo.onChange = [this] { scanPresetDirectory(); };
+
+  loadButton.onClick = [this] { loadSelectedPreset(); };
+  saveButton.onClick = [this] { savePreset(); };
+
+  presetDirectory =
+      juce::File::getSpecialLocation(juce::File::userDocumentsDirectory)
+          .getChildFile("PointilSynthPresets");
+  presetDirectory.createDirectory();
+
+  scanPresetDirectory();
+}
+
+void PresetBrowserComponent::paint(juce::Graphics& g) {
+  g.fillAll(
+      getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
+}
+
+void PresetBrowserComponent::resized() {
+  auto area = getLocalBounds().reduced(5);
+  categoryCombo.setBounds(area.removeFromTop(25));
+  presetList.setBounds(area.removeFromTop(getHeight() - 90));
+  loadButton.setBounds(area.removeFromTop(25).removeFromLeft(60));
+  presetNameEditor.setBounds(area.removeFromTop(25).removeFromLeft(150));
+  saveButton.setBounds(area.removeFromTop(25).removeFromLeft(60));
+}
+
+int PresetBrowserComponent::getNumRows() {
+  return static_cast<int>(presets.size());
+}
+
+void PresetBrowserComponent::paintListBoxItem(int rowNumber,
+                                              juce::Graphics& g,
+                                              int width,
+                                              int height,
+                                              bool rowIsSelected) {
+  if (rowNumber < 0 || rowNumber >= getNumRows())
+    return;
+
+  if (rowIsSelected) {
+    g.fillAll(juce::Colours::lightblue);
+  }
+  g.setColour(juce::Colours::white);
+  g.drawText(presets[static_cast<size_t>(rowNumber)]
+                 .file.getFileNameWithoutExtension(),
+             0, 0, width, height, juce::Justification::centredLeft, true);
+}
+
+void PresetBrowserComponent::scanPresetDirectory() {
+  presets.clear();
+  juce::String selected = categoryCombo.getText();
+  if (selected.isEmpty())
+    selected = "All";
+  auto files =
+      presetDirectory.findChildFiles(juce::File::findFiles, false, "*.json");
+  for (auto& f : files) {
+    juce::String category;
+    juce::FileInputStream in(f);
+    if (in.openedOk()) {
+      auto text = in.readEntireStreamAsString();
+      try {
+        auto j = nlohmann::json::parse(text.toStdString());
+        if (j.contains("category"))
+          category = j["category"].get<std::string>();
+      } catch (...) {
+      }
+    }
+    if (selected == "All" || category == selected)
+      presets.push_back({f, category});
+  }
+  presetList.updateContent();
+  presetList.repaint();
+}
+
+void PresetBrowserComponent::loadSelectedPreset() {
+  int row = presetList.getSelectedRow();
+  if (row >= 0 && row < getNumRows())
+    presetManager.loadPreset(presets[static_cast<size_t>(row)].file);
+}
+
+void PresetBrowserComponent::savePreset() {
+  auto name = presetNameEditor.getText();
+  if (name.isEmpty())
+    return;
+  juce::File file =
+      presetDirectory.getChildFile(name).withFileExtension(".json");
+  if (presetManager.savePreset(file)) {
+    juce::String category = categoryCombo.getText();
+    if (category == "All")
+      category = "Uncategorized";
+    juce::FileInputStream in(file);
+    nlohmann::json j;
+    if (in.openedOk()) {
+      auto text = in.readEntireStreamAsString();
+      try {
+        j = nlohmann::json::parse(text.toStdString());
+      } catch (...) {
+        j = nlohmann::json{};
+      }
+    }
+    j["category"] = category.toStdString();
+    juce::FileOutputStream out(file);
+    std::string data = j.dump(4);
+    out.write(data.c_str(), data.size());
+    scanPresetDirectory();
+  }
+}
+
+}  // namespace audio_plugin

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_SOURCE_FILES
     source/PluginProcessorTest.cpp
     source/PointilismInterfacesTest.cpp
     source/PresetManagerTest.cpp
+    source/UI/PresetBrowserComponentTest.cpp
     source/ResamplerTest.cpp
 )
 set_source_files_properties(${SOURCE_FILES} PROPERTIES COMPILE_OPTIONS "${PROJECT_WARNINGS_CXX}")

--- a/test/source/UI/PresetBrowserComponentTest.cpp
+++ b/test/source/UI/PresetBrowserComponentTest.cpp
@@ -1,0 +1,23 @@
+#include "UI/PresetBrowserComponent.h"
+#include "Pointilsynth/PresetManager.h"
+#include "Pointilsynth/PointilismInterfaces.h"
+#include "Pointilsynth/PluginProcessor.h"
+#include <gtest/gtest.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace audio_plugin {
+
+struct PresetBrowserTestFixture : public ::testing::Test {
+  PresetBrowserTestFixture() = default;
+  juce::ScopedJuceInitialiser_GUI libraryInitialiser;
+};
+
+TEST_F(PresetBrowserTestFixture, CanConstruct) {
+  AudioPluginAudioProcessor processor;
+  auto cfg = ConfigManager::getInstance(&processor);
+  StochasticModel model(cfg);
+  Pointilism::PresetManager manager(model);
+  EXPECT_NO_THROW(PresetBrowserComponent browser(manager));
+}
+
+}  // namespace audio_plugin


### PR DESCRIPTION
## Summary
- add `PresetBrowserComponent` for browsing, loading and saving presets
- register new component sources in build system
- add basic construction test for the component

## Testing
- `pre-commit run --files plugin/include/UI/PresetBrowserComponent.h plugin/source/UI/PresetBrowserComponent.cpp plugin/CMakeLists.txt test/source/UI/PresetBrowserComponentTest.cpp test/CMakeLists.txt`
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`

------
https://chatgpt.com/codex/tasks/task_e_6850506ae2008323a60914c2dca670d9