### PR TITLE
Implement PodComponent with APVTS attachment

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SOURCE_FILES
     source/PluginEditor.cpp
     source/PresetManager.cpp
     source/UI/PresetBrowserComponent.cpp
+    source/UI/PodComponent.cpp
     source/StochasticModel.cpp
 )
 # Optional; includes header files in the project file tree in Visual Studio

--- a/plugin/include/PodComponent.h
+++ b/plugin/include/PodComponent.h
@@ -1,15 +1,27 @@
 #pragma once
 
 #include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <memory>
 
 namespace audio_plugin {
 
 class PodComponent : public juce::Component {
 public:
-  PodComponent() = default;
+  PodComponent(juce::AudioProcessorValueTreeState& apvts,
+               juce::String paramID,
+               juce::String displayName);
   ~PodComponent() override = default;
 
+  void paint(juce::Graphics&) override;
+  void resized() override;
+
 private:
+  juce::Slider slider;
+  juce::Label label;
+
+  using SliderAttachment = juce::AudioProcessorValueTreeState::SliderAttachment;
+  std::unique_ptr<SliderAttachment> attachment;
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PodComponent)
 };
 

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -8,7 +8,19 @@ PointillisticSynthAudioProcessorEditor::PointillisticSynthAudioProcessorEditor(
     audio_plugin::AudioPluginAudioProcessor& p)
     : juce::AudioProcessorEditor(&p),
       processorRef(p),
-      debugUIPanel(processorRef.getConfigManager()) {
+      debugUIPanel(processorRef.getConfigManager()),
+      pitchPod(ConfigManager::getInstance(&processorRef)->getAPVTS(),
+               ConfigManager::ParamID::pitch,
+               "Pitch"),
+      densityPod(ConfigManager::getInstance()->getAPVTS(),
+                 ConfigManager::ParamID::density,
+                 "Density"),
+      durationPod(ConfigManager::getInstance()->getAPVTS(),
+                  ConfigManager::ParamID::avgDuration,
+                  "Duration"),
+      panPod(ConfigManager::getInstance()->getAPVTS(),
+             ConfigManager::ParamID::pan,
+             "Pan") {
   addAndMakeVisible(pitchPod);
   addAndMakeVisible(densityPod);
   addAndMakeVisible(durationPod);

--- a/plugin/source/UI/PodComponent.cpp
+++ b/plugin/source/UI/PodComponent.cpp
@@ -1,0 +1,33 @@
+#include "PodComponent.h"
+
+namespace audio_plugin {
+
+PodComponent::PodComponent(juce::AudioProcessorValueTreeState& apvts,
+                           juce::String paramID,
+                           juce::String displayName) {
+  addAndMakeVisible(slider);
+  slider.setSliderStyle(juce::Slider::RotaryVerticalDrag);
+  slider.setTextBoxStyle(juce::Slider::NoTextBox, false, 0, 0);
+
+  addAndMakeVisible(label);
+  label.setText(displayName, juce::dontSendNotification);
+  label.setJustificationType(juce::Justification::centred);
+
+  attachment =
+      std::make_unique<PodComponent::SliderAttachment>(apvts, paramID, slider);
+}
+
+void PodComponent::paint(juce::Graphics& g) {
+  g.setColour(juce::Colours::darkgrey);
+  g.fillRoundedRectangle(getLocalBounds().toFloat(), 4.0f);
+  g.setColour(juce::Colours::white);
+  g.drawRoundedRectangle(getLocalBounds().toFloat(), 4.0f, 1.0f);
+}
+
+void PodComponent::resized() {
+  auto area = getLocalBounds();
+  label.setBounds(area.removeFromBottom(20));
+  slider.setBounds(area.reduced(10));
+}
+
+}  // namespace audio_plugin

--- a/test/source/UI/PodComponentTest.cpp
+++ b/test/source/UI/PodComponentTest.cpp
@@ -1,15 +1,22 @@
 #include "PodComponent.h"  // Defines audio_plugin::PodComponent
+#include "Pointilsynth/ConfigManager.h"
+#include "Pointilsynth/PluginProcessor.h"
 #include <gtest/gtest.h>
 #include <juce_gui_basics/juce_gui_basics.h>  // For ScopedJuceInitialiser_GUI
 
 namespace audio_plugin {
 // Minimal ScopedJuceInitialiser_GUI for tests needing it.
-struct JuceGuiTestFixture : public ::testing::Test {
-  JuceGuiTestFixture() = default;
+struct PodComponentTestFixture : public ::testing::Test {
+  PodComponentTestFixture() = default;
+  ~PodComponentTestFixture() override { ConfigManager::resetInstance(); }
+
   juce::ScopedJuceInitialiser_GUI libraryInitialiser;
+  AudioPluginAudioProcessor processor;
 };
 
-TEST_F(JuceGuiTestFixture, PodComponentCanConstruct) {
-  EXPECT_NO_THROW(std::make_unique<PodComponent>());
+TEST_F(PodComponentTestFixture, PodComponentCanConstruct) {
+  auto& apvts = ConfigManager::getInstance(&processor)->getAPVTS();
+  EXPECT_NO_THROW(std::make_unique<PodComponent>(
+      apvts, ConfigManager::ParamID::pitch, "Pitch"));
 }
 }  // namespace audio_plugin


### PR DESCRIPTION
## Summary
- add SliderAttachment for PodComponent and implement UI layout
- wire Pods in PluginEditor to APVTS using ConfigManager
- include new PodComponent.cpp in CMake build
- update PodComponent unit test for new constructor

## Testing
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`

------
https://chatgpt.com/codex/tasks/task_e_6850581856888323aff5fb98f39d293c