### PR TITLE
Add OpenGL visualization component

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SOURCE_FILES
     source/DebugUIPanel.cpp
     source/PluginProcessor.cpp
     source/PluginEditor.cpp
+    source/UI/VisualizationComponent.cpp
     source/PresetManager.cpp
     source/StochasticModel.cpp
 )
@@ -62,6 +63,7 @@ set(HEADER_FILES
     ${INCLUDE_DIR}/PresetManager.h
     ${INCLUDE_DIR}/Resampler.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/PodComponent.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/UI/VisualizationComponent.h
 )
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCE_FILES} ${HEADER_FILES})
 
@@ -82,6 +84,7 @@ target_link_libraries_system(
   juce::juce_core
   juce::juce_dsp
   juce::juce_gui_basics
+  juce::juce_opengl
   nlohmann_json::nlohmann_json
 )
 

--- a/plugin/include/Pointilsynth/PluginEditor.h
+++ b/plugin/include/Pointilsynth/PluginEditor.h
@@ -3,6 +3,7 @@
 #include "PluginProcessor.h"  // Adjusted path
 #include "DebugUIPanel.h"     // Added for DebugUIPanel
 #include "PodComponent.h"     // Placeholder pod controls
+#include "UI/VisualizationComponent.h"
 // PointilismInterfaces.h is included by PluginProcessor.h, which is included
 // above. If direct use of StochasticModel type was needed here, an include
 // would be good: #include "../../source/PointilismInterfaces.h"
@@ -30,6 +31,7 @@ private:
   PodComponent densityPod;
   PodComponent durationPod;
   PodComponent panPod;
+  VisualizationComponent visualization;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(
       PointillisticSynthAudioProcessorEditor)

--- a/plugin/include/UI/VisualizationComponent.h
+++ b/plugin/include/UI/VisualizationComponent.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_opengl/juce_opengl.h>
+#include <vector>
+
+namespace audio_plugin {
+
+class VisualizationComponent : public juce::Component, public juce::Timer {
+public:
+  VisualizationComponent();
+  ~VisualizationComponent() override;
+
+  void paint(juce::Graphics& g) override;
+  void timerCallback() override;
+
+private:
+  struct MockGrain {
+    float pan = 0.0f;
+    float pitch = 60.0f;
+    float size = 4.0f;
+    juce::Colour colour;
+    double startTime = 0.0;
+    double maxAge = 1.0;
+  };
+
+  juce::OpenGLContext openGLContext_;
+  std::vector<MockGrain> grains_;
+
+  JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(VisualizationComponent)
+};
+
+}  // namespace audio_plugin

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -13,6 +13,7 @@ PointillisticSynthAudioProcessorEditor::PointillisticSynthAudioProcessorEditor(
   addAndMakeVisible(densityPod);
   addAndMakeVisible(durationPod);
   addAndMakeVisible(panPod);
+  addAndMakeVisible(visualization);
 
   setSize(600, 400);  // Example size, can be adjusted
 }
@@ -25,22 +26,14 @@ void PointillisticSynthAudioProcessorEditor::paint(juce::Graphics& g) {
   g.fillAll(
       getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
 
-  // You can add drawing code here for the visualization area if needed,
-  // or leave it blank if it's handled by another component.
-  // For now, let's draw a placeholder for the visualization area.
-  auto visArea = getLocalBounds().removeFromTop(getHeight() * 2 / 3);
-  g.setColour(juce::Colours::darkgrey);
-  g.fillRect(visArea);
-  g.setColour(juce::Colours::white);
-  g.drawText("Visualization Area", visArea, juce::Justification::centred,
-             false);
+  // Visualization is handled by the VisualizationComponent.
 }
 
 void PointillisticSynthAudioProcessorEditor::resized() {
   auto bounds = getLocalBounds();
 
-  // Top two-thirds for visualization (currently empty or placeholder)
-  bounds.removeFromTop(getHeight() * 2 / 3);
+  auto visArea = bounds.removeFromTop(getHeight() * 2 / 3);
+  visualization.setBounds(visArea);
 
   // Bottom third for the pods
   auto podArea = bounds;

--- a/plugin/source/UI/VisualizationComponent.cpp
+++ b/plugin/source/UI/VisualizationComponent.cpp
@@ -1,0 +1,70 @@
+#include "UI/VisualizationComponent.h"
+
+#include <juce_graphics/juce_graphics.h>
+#include <random>
+
+namespace audio_plugin {
+
+namespace {
+inline double getCurrentTimeInSeconds() {
+  return juce::Time::getMillisecondCounterHiRes() / 1000.0;
+}
+
+float randomRange(float min, float max) {
+  return juce::Random::getSystemRandom().nextFloat() * (max - min) + min;
+}
+}  // namespace
+
+VisualizationComponent::VisualizationComponent() {
+  openGLContext_.attachTo(*this);
+  startTimerHz(60);
+}
+
+VisualizationComponent::~VisualizationComponent() {
+  openGLContext_.detach();
+}
+
+void VisualizationComponent::timerCallback() {
+  const double now = getCurrentTimeInSeconds();
+
+  grains_.erase(std::remove_if(grains_.begin(), grains_.end(),
+                               [now](const MockGrain& g) {
+                                 return now - g.startTime > g.maxAge;
+                               }),
+                grains_.end());
+
+  if (grains_.size() < 256) {
+    int numNew = juce::Random::getSystemRandom().nextInt(5);  // 0-4
+    for (int i = 0; i < numNew && grains_.size() < 256; ++i) {
+      MockGrain g;
+      g.pan = randomRange(-1.0f, 1.0f);
+      g.pitch = randomRange(21.0f, 108.0f);
+      g.size = randomRange(2.0f, 6.0f);
+      g.colour =
+          juce::Colour::fromHSV(randomRange(0.0f, 1.0f), 0.8f, 1.0f, 1.0f);
+      g.startTime = now;
+      g.maxAge = randomRange(1.0f, 4.0f);
+      grains_.push_back(g);
+    }
+  }
+
+  repaint();
+}
+
+void VisualizationComponent::paint(juce::Graphics& g) {
+  g.fillAll(juce::Colours::black);
+
+  const auto width = static_cast<float>(getWidth());
+  const auto height = static_cast<float>(getHeight());
+
+  for (const auto& grain : grains_) {
+    const float x = juce::jmap(grain.pan, -1.0f, 1.0f, 0.0f, width);
+    const float y = juce::jmap(grain.pitch, 108.0f, 21.0f, 0.0f, height);
+
+    g.setColour(grain.colour);
+    g.fillEllipse(x - grain.size * 0.5f, y - grain.size * 0.5f, grain.size,
+                  grain.size);
+  }
+}
+
+}  // namespace audio_plugin


### PR DESCRIPTION
## Summary
- draw realtime grain visualization with `VisualizationComponent`
- hook `VisualizationComponent` into plugin editor
- add OpenGL dependency and new sources in build

## Testing
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`


------
https://chatgpt.com/codex/tasks/task_e_685053cea7308323a9c64b211debba12