### PR TITLE
Refactor UI component attachments

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SOURCE_FILES
     source/PluginEditor.cpp
     source/PresetManager.cpp
     source/UI/PresetBrowserComponent.cpp
+    source/PodComponent.cpp
     source/StochasticModel.cpp
 )
 # Optional; includes header files in the project file tree in Visual Studio

--- a/plugin/include/PodComponent.h
+++ b/plugin/include/PodComponent.h
@@ -6,10 +6,14 @@ namespace audio_plugin {
 
 class PodComponent : public juce::Component {
 public:
-  PodComponent() = default;
-  ~PodComponent() override = default;
+  PodComponent(const juce::String& paramID, const juce::String& displayName);
+  ~PodComponent() override;
+
+  void resized() override;
 
 private:
+  std::unique_ptr<juce::Slider> slider_;
+  juce::String displayName_;
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PodComponent)
 };
 

--- a/plugin/include/Pointilsynth/ConfigManager.h
+++ b/plugin/include/Pointilsynth/ConfigManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 #include <memory>
 #include <functional>
 #include <unordered_map>
@@ -24,10 +25,17 @@ public:
   static std::shared_ptr<ConfigManager> getInstance(
       juce::AudioProcessor* processor = nullptr);
   static void resetInstance();
-  juce::AudioProcessorValueTreeState& getAPVTS();
   void addListener(const juce::String& paramID, Callback cb);
 
+  std::unique_ptr<juce::Slider> createAttachedSlider(
+      const juce::String& paramID);
+  std::unique_ptr<juce::ComboBox> createAttachedComboBox(
+      const juce::String& paramID);
+  void releaseAttachment(juce::Slider* slider);
+  void releaseAttachment(juce::ComboBox* box);
+
 private:
+  juce::AudioProcessorValueTreeState& getAPVTS();
   class FunctionListener : public juce::AudioProcessorValueTreeState::Listener {
   public:
     explicit FunctionListener(Callback fn) : fn_(std::move(fn)) {}
@@ -45,6 +53,14 @@ private:
   std::unordered_map<juce::String,
                      std::vector<std::unique_ptr<FunctionListener>>>
       listeners_;
+  std::vector<std::pair<
+      juce::Slider*,
+      std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment>>>
+      sliderAttachments_;
+  std::vector<std::pair<
+      juce::ComboBox*,
+      std::unique_ptr<juce::AudioProcessorValueTreeState::ComboBoxAttachment>>>
+      comboBoxAttachments_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ConfigManager)
 };

--- a/plugin/include/Pointilsynth/DebugUIPanel.h
+++ b/plugin/include/Pointilsynth/DebugUIPanel.h
@@ -19,40 +19,29 @@ private:
   std::shared_ptr<ConfigManager> configManager;
 
   // UI Components
-  juce::Slider pitchSlider;
+  std::unique_ptr<juce::Slider> pitchSlider;
   juce::Label pitchLabel;
-  juce::Slider dispersionSlider;
+  std::unique_ptr<juce::Slider> dispersionSlider;
   juce::Label dispersionLabel;
-
-  juce::Slider durationSlider;
+  std::unique_ptr<juce::Slider> durationSlider;
   juce::Label durationLabel;
-  juce::Slider durationVariationSlider;
+  std::unique_ptr<juce::Slider> durationVariationSlider;
   juce::Label durationVariationLabel;
-
-  juce::Slider panSlider;
+  std::unique_ptr<juce::Slider> panSlider;
   juce::Label panLabel;
-  juce::Slider panSpreadSlider;
+  std::unique_ptr<juce::Slider> panSpreadSlider;
   juce::Label panSpreadLabel;
-
-  juce::Slider densitySlider;
+  std::unique_ptr<juce::Slider> densitySlider;
   juce::Label densityLabel;
 
-  juce::ComboBox temporalDistributionComboBox;
+  std::unique_ptr<juce::ComboBox> temporalDistributionComboBox;
   juce::Label temporalDistributionLabel;
 
   // Parameter attachments (declared after the components they reference so that
   // they are destroyed first).
-  using SliderAttachment = juce::AudioProcessorValueTreeState::SliderAttachment;
   using ComboBoxAttachment =
       juce::AudioProcessorValueTreeState::ComboBoxAttachment;
 
-  std::unique_ptr<SliderAttachment> pitchAttachment;
-  std::unique_ptr<SliderAttachment> dispersionAttachment;
-  std::unique_ptr<SliderAttachment> durationAttachment;
-  std::unique_ptr<SliderAttachment> durationVariationAttachment;
-  std::unique_ptr<SliderAttachment> panAttachment;
-  std::unique_ptr<SliderAttachment> panSpreadAttachment;
-  std::unique_ptr<SliderAttachment> densityAttachment;
   std::unique_ptr<ComboBoxAttachment> temporalDistributionAttachment;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DebugUIPanel)

--- a/plugin/source/DebugUIPanel.cpp
+++ b/plugin/source/DebugUIPanel.cpp
@@ -7,111 +7,97 @@ DebugUIPanel::DebugUIPanel(std::shared_ptr<ConfigManager> cfg)
     : configManager(std::move(cfg)) {
   // Initialize and configure sliders and labels
   // Pitch
-  addAndMakeVisible(pitchSlider);
-  pitchSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-  pitchSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-  pitchSlider.setRange(20.0, 100.0, 0.1);  // MIDI note numbers
-  if (configManager)
-    pitchAttachment = std::make_unique<SliderAttachment>(
-        configManager->getAPVTS(), ConfigManager::ParamID::pitch, pitchSlider);
+  pitchSlider =
+      configManager->createAttachedSlider(ConfigManager::ParamID::pitch);
+  pitchSlider->setRange(20.0, 100.0, 0.1);  // MIDI note numbers
+  pitchSlider->setSliderStyle(juce::Slider::LinearHorizontal);
+  pitchSlider->setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  addAndMakeVisible(*pitchSlider);
   addAndMakeVisible(pitchLabel);
   pitchLabel.setText("Pitch", juce::dontSendNotification);
-  pitchLabel.attachToComponent(&pitchSlider, true);  // true for onLeft
+  pitchLabel.attachToComponent(pitchSlider.get(), true);  // true for onLeft
 
   // Dispersion
-  addAndMakeVisible(dispersionSlider);
-  dispersionSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-  dispersionSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-  dispersionSlider.setRange(0.0, 24.0, 0.1);  // Semitones
-  if (configManager)
-    dispersionAttachment = std::make_unique<SliderAttachment>(
-        configManager->getAPVTS(), ConfigManager::ParamID::dispersion,
-        dispersionSlider);
+  dispersionSlider =
+      configManager->createAttachedSlider(ConfigManager::ParamID::dispersion);
+  dispersionSlider->setSliderStyle(juce::Slider::LinearHorizontal);
+  dispersionSlider->setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  dispersionSlider->setRange(0.0, 24.0, 0.1);  // Semitones
+  addAndMakeVisible(*dispersionSlider);
   addAndMakeVisible(dispersionLabel);
   dispersionLabel.setText("Dispersion", juce::dontSendNotification);
-  dispersionLabel.attachToComponent(&dispersionSlider, true);
+  dispersionLabel.attachToComponent(dispersionSlider.get(), true);
 
   // Duration
-  addAndMakeVisible(durationSlider);
-  durationSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-  durationSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-  durationSlider.setRange(10.0, 1000.0, 1.0);  // Milliseconds
-  if (configManager)
-    durationAttachment = std::make_unique<SliderAttachment>(
-        configManager->getAPVTS(), ConfigManager::ParamID::avgDuration,
-        durationSlider);
+  durationSlider =
+      configManager->createAttachedSlider(ConfigManager::ParamID::avgDuration);
+  durationSlider->setSliderStyle(juce::Slider::LinearHorizontal);
+  durationSlider->setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  durationSlider->setRange(10.0, 1000.0, 1.0);  // Milliseconds
+  addAndMakeVisible(*durationSlider);
   addAndMakeVisible(durationLabel);
   durationLabel.setText("Duration (ms)", juce::dontSendNotification);
-  durationLabel.attachToComponent(&durationSlider, true);
+  durationLabel.attachToComponent(durationSlider.get(), true);
 
   // Duration Variation
-  addAndMakeVisible(durationVariationSlider);
-  durationVariationSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-  durationVariationSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80,
-                                          20);
-  durationVariationSlider.setRange(0.0, 1.0, 0.01);  // Percentage
-  if (configManager)
-    durationVariationAttachment = std::make_unique<SliderAttachment>(
-        configManager->getAPVTS(), ConfigManager::ParamID::durationVariation,
-        durationVariationSlider);
+  durationVariationSlider = configManager->createAttachedSlider(
+      ConfigManager::ParamID::durationVariation);
+  durationVariationSlider->setSliderStyle(juce::Slider::LinearHorizontal);
+  durationVariationSlider->setTextBoxStyle(juce::Slider::TextBoxRight, false,
+                                           80, 20);
+  durationVariationSlider->setRange(0.0, 1.0, 0.01);  // Percentage
+  addAndMakeVisible(*durationVariationSlider);
   addAndMakeVisible(durationVariationLabel);
   durationVariationLabel.setText("Duration Var.", juce::dontSendNotification);
-  durationVariationLabel.attachToComponent(&durationVariationSlider, true);
+  durationVariationLabel.attachToComponent(durationVariationSlider.get(), true);
 
   // Pan
-  addAndMakeVisible(panSlider);
-  panSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-  panSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-  panSlider.setRange(-1.0, 1.0, 0.01);  // -1 (L) to 1 (R)
-  if (configManager)
-    panAttachment = std::make_unique<SliderAttachment>(
-        configManager->getAPVTS(), ConfigManager::ParamID::pan, panSlider);
+  panSlider = configManager->createAttachedSlider(ConfigManager::ParamID::pan);
+  panSlider->setSliderStyle(juce::Slider::LinearHorizontal);
+  panSlider->setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  panSlider->setRange(-1.0, 1.0, 0.01);  // -1 (L) to 1 (R)
+  addAndMakeVisible(*panSlider);
   addAndMakeVisible(panLabel);
   panLabel.setText("Pan", juce::dontSendNotification);
-  panLabel.attachToComponent(&panSlider, true);
+  panLabel.attachToComponent(panSlider.get(), true);
 
   // Pan Spread
-  addAndMakeVisible(panSpreadSlider);
-  panSpreadSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-  panSpreadSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-  panSpreadSlider.setRange(0.0, 1.0, 0.01);  // Spread amount
-  if (configManager)
-    panSpreadAttachment = std::make_unique<SliderAttachment>(
-        configManager->getAPVTS(), ConfigManager::ParamID::panSpread,
-        panSpreadSlider);
+  panSpreadSlider =
+      configManager->createAttachedSlider(ConfigManager::ParamID::panSpread);
+  panSpreadSlider->setSliderStyle(juce::Slider::LinearHorizontal);
+  panSpreadSlider->setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  panSpreadSlider->setRange(0.0, 1.0, 0.01);  // Spread amount
+  addAndMakeVisible(*panSpreadSlider);
   addAndMakeVisible(panSpreadLabel);
   panSpreadLabel.setText("Pan Spread", juce::dontSendNotification);
-  panSpreadLabel.attachToComponent(&panSpreadSlider, true);
+  panSpreadLabel.attachToComponent(panSpreadSlider.get(), true);
 
   // Density
-  addAndMakeVisible(densitySlider);
-  densitySlider.setSliderStyle(juce::Slider::LinearHorizontal);
-  densitySlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
-  densitySlider.setRange(0.1, 50.0, 0.1);  // Grains per second
-  if (configManager)
-    densityAttachment = std::make_unique<SliderAttachment>(
-        configManager->getAPVTS(), ConfigManager::ParamID::density,
-        densitySlider);
+  densitySlider =
+      configManager->createAttachedSlider(ConfigManager::ParamID::density);
+  densitySlider->setSliderStyle(juce::Slider::LinearHorizontal);
+  densitySlider->setTextBoxStyle(juce::Slider::TextBoxRight, false, 80, 20);
+  densitySlider->setRange(0.1, 50.0, 0.1);  // Grains per second
+  addAndMakeVisible(*densitySlider);
   addAndMakeVisible(densityLabel);
   densityLabel.setText("Density (gr/s)", juce::dontSendNotification);
-  densityLabel.attachToComponent(&densitySlider, true);
+  densityLabel.attachToComponent(densitySlider.get(), true);
 
   // Temporal Distribution
-  addAndMakeVisible(temporalDistributionComboBox);
-  temporalDistributionComboBox.addItem(
+  temporalDistributionComboBox = configManager->createAttachedComboBox(
+      ConfigManager::ParamID::temporalDistribution);
+  addAndMakeVisible(*temporalDistributionComboBox);
+  temporalDistributionComboBox->addItem(
       "Uniform",
       static_cast<int>(StochasticModel::TemporalDistribution::Uniform) + 1);
-  temporalDistributionComboBox.addItem(
+  temporalDistributionComboBox->addItem(
       "Poisson",
       static_cast<int>(StochasticModel::TemporalDistribution::Poisson) + 1);
-  if (configManager)
-    temporalDistributionAttachment = std::make_unique<ComboBoxAttachment>(
-        configManager->getAPVTS(), ConfigManager::ParamID::temporalDistribution,
-        temporalDistributionComboBox);
+  // Attachment created by ConfigManager
   addAndMakeVisible(temporalDistributionLabel);
   temporalDistributionLabel.setText("Distribution", juce::dontSendNotification);
-  temporalDistributionLabel.attachToComponent(&temporalDistributionComboBox,
-                                              true);
+  temporalDistributionLabel.attachToComponent(
+      temporalDistributionComboBox.get(), true);
 
   // The editor is responsible for setting our size.
   // setSize(600, 400); // This was set by PluginEditor
@@ -121,6 +107,16 @@ DebugUIPanel::~DebugUIPanel() {
   // Destructor (JUCE handles cleanup of child components as they are owned)
   // Listeners are lambda based and managed by JUCE Slider/ComboBox, no manual
   // removal needed.
+  if (configManager) {
+    configManager->releaseAttachment(pitchSlider.get());
+    configManager->releaseAttachment(dispersionSlider.get());
+    configManager->releaseAttachment(durationSlider.get());
+    configManager->releaseAttachment(durationVariationSlider.get());
+    configManager->releaseAttachment(panSlider.get());
+    configManager->releaseAttachment(panSpreadSlider.get());
+    configManager->releaseAttachment(densitySlider.get());
+    configManager->releaseAttachment(temporalDistributionComboBox.get());
+  }
 }
 
 void DebugUIPanel::paint(juce::Graphics& g) {
@@ -156,14 +152,14 @@ void DebugUIPanel::resized() {
   // For attached labels, their width is part of the component they are attached
   // to. The FlexBox will lay out the main components (sliders, combobox).
 
-  addItemToFlexBox(pitchSlider, standardItemHeight);
-  addItemToFlexBox(dispersionSlider, standardItemHeight);
-  addItemToFlexBox(durationSlider, standardItemHeight);
-  addItemToFlexBox(durationVariationSlider, standardItemHeight);
-  addItemToFlexBox(panSlider, standardItemHeight);
-  addItemToFlexBox(panSpreadSlider, standardItemHeight);
-  addItemToFlexBox(densitySlider, standardItemHeight);
-  addItemToFlexBox(temporalDistributionComboBox, standardItemHeight);
+  addItemToFlexBox(*pitchSlider, standardItemHeight);
+  addItemToFlexBox(*dispersionSlider, standardItemHeight);
+  addItemToFlexBox(*durationSlider, standardItemHeight);
+  addItemToFlexBox(*durationVariationSlider, standardItemHeight);
+  addItemToFlexBox(*panSlider, standardItemHeight);
+  addItemToFlexBox(*panSpreadSlider, standardItemHeight);
+  addItemToFlexBox(*densitySlider, standardItemHeight);
+  addItemToFlexBox(*temporalDistributionComboBox, standardItemHeight);
 
   // Perform layout within the panel's bounds, reduced by a margin for
   // aesthetics

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -8,7 +8,11 @@ PointillisticSynthAudioProcessorEditor::PointillisticSynthAudioProcessorEditor(
     audio_plugin::AudioPluginAudioProcessor& p)
     : juce::AudioProcessorEditor(&p),
       processorRef(p),
-      debugUIPanel(processorRef.getConfigManager()) {
+      debugUIPanel(processorRef.getConfigManager()),
+      pitchPod(ConfigManager::ParamID::pitch, "Pitch"),
+      densityPod(ConfigManager::ParamID::density, "Density"),
+      durationPod(ConfigManager::ParamID::avgDuration, "Duration"),
+      panPod(ConfigManager::ParamID::pan, "Pan") {
   addAndMakeVisible(pitchPod);
   addAndMakeVisible(densityPod);
   addAndMakeVisible(durationPod);

--- a/plugin/source/PodComponent.cpp
+++ b/plugin/source/PodComponent.cpp
@@ -1,0 +1,23 @@
+#include "PodComponent.h"
+#include "Pointilsynth/ConfigManager.h"
+
+namespace audio_plugin {
+
+PodComponent::PodComponent(const juce::String& paramID,
+                           const juce::String& displayName)
+    : displayName_(displayName) {
+  slider_ = ConfigManager::getInstance()->createAttachedSlider(paramID);
+  addAndMakeVisible(*slider_);
+}
+
+PodComponent::~PodComponent() {
+  if (slider_)
+    ConfigManager::getInstance()->releaseAttachment(slider_.get());
+}
+
+void PodComponent::resized() {
+  if (slider_)
+    slider_->setBounds(getLocalBounds());
+}
+
+}  // namespace audio_plugin

--- a/test/source/UI/PodComponentTest.cpp
+++ b/test/source/UI/PodComponentTest.cpp
@@ -1,4 +1,5 @@
 #include "PodComponent.h"  // Defines audio_plugin::PodComponent
+#include "Pointilsynth/ConfigManager.h"
 #include <gtest/gtest.h>
 #include <juce_gui_basics/juce_gui_basics.h>  // For ScopedJuceInitialiser_GUI
 
@@ -10,6 +11,7 @@ struct JuceGuiTestFixture : public ::testing::Test {
 };
 
 TEST_F(JuceGuiTestFixture, PodComponentCanConstruct) {
-  EXPECT_NO_THROW(std::make_unique<PodComponent>());
+  EXPECT_NO_THROW(
+      std::make_unique<PodComponent>(ConfigManager::ParamID::pitch, "Pitch"));
 }
 }  // namespace audio_plugin


### PR DESCRIPTION
## Summary
- hide APVTS internals in `ConfigManager`
- add factory methods to create attached sliders and combo boxes
- manage attachments centrally and release them when components are destroyed
- refactor `PodComponent` and `DebugUIPanel` to use the new factory
- update `PluginEditor` and tests

## Testing
- `pre-commit run --files plugin/CMakeLists.txt plugin/include/Pointilsynth/ConfigManager.h plugin/source/ConfigManager.cpp plugin/include/PodComponent.h plugin/source/PodComponent.cpp plugin/source/PluginEditor.cpp plugin/include/Pointilsynth/DebugUIPanel.h plugin/source/DebugUIPanel.cpp test/source/UI/PodComponentTest.cpp`
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`

------
https://chatgpt.com/codex/tasks/task_e_68505b6b30f8832386b60b9d1ffc76e1