### PR TITLE
Add OpenGL-based grain visualization

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SOURCE_FILES
     source/PluginEditor.cpp
     source/PresetManager.cpp
     source/UI/PresetBrowserComponent.cpp
+    source/UI/VisualizationComponent.cpp
     source/PodComponent.cpp
     source/StochasticModel.cpp
 )
@@ -64,6 +65,7 @@ set(HEADER_FILES
     ${INCLUDE_DIR}/PresetManager.h
     ${INCLUDE_DIR}/Resampler.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/UI/PresetBrowserComponent.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/UI/VisualizationComponent.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/PodComponent.h
 )
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCE_FILES} ${HEADER_FILES})
@@ -84,6 +86,7 @@ target_link_libraries_system(
   juce::juce_audio_processors
   juce::juce_core
   juce::juce_dsp
+  juce::juce_opengl
   juce::juce_gui_basics
   nlohmann_json::nlohmann_json
 )

--- a/plugin/include/Pointilsynth/PluginEditor.h
+++ b/plugin/include/Pointilsynth/PluginEditor.h
@@ -3,6 +3,7 @@
 #include "PluginProcessor.h"  // Adjusted path
 #include "DebugUIPanel.h"     // Added for DebugUIPanel
 #include "PodComponent.h"     // Placeholder pod controls
+#include "UI/VisualizationComponent.h"
 // PointilismInterfaces.h is included by PluginProcessor.h, which is included
 // above. If direct use of StochasticModel type was needed here, an include
 // would be good: #include "../../source/PointilismInterfaces.h"
@@ -30,6 +31,7 @@ private:
   PodComponent densityPod;
   PodComponent durationPod;
   PodComponent panPod;
+  VisualizationComponent visualizationComponent;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(
       PointillisticSynthAudioProcessorEditor)

--- a/plugin/include/UI/VisualizationComponent.h
+++ b/plugin/include/UI/VisualizationComponent.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_opengl/juce_opengl.h>
+
+namespace audio_plugin {
+
+class VisualizationComponent : public juce::Component, public juce::Timer {
+public:
+  VisualizationComponent();
+  ~VisualizationComponent() override;
+
+  void paint(juce::Graphics& g) override;
+  void timerCallback() override;
+
+private:
+  struct MockGrain {
+    float pan{};    // -1.0 to 1.0
+    float pitch{};  // 21.0 to 108.0
+    float size{};   // pixel radius
+    juce::Colour colour;
+    double startTime{};  // seconds
+    double maxAge{};     // seconds
+  };
+
+  juce::OpenGLContext openGLContext;
+  std::vector<MockGrain> grains;
+
+  JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(VisualizationComponent)
+};
+
+}  // namespace audio_plugin

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -13,6 +13,7 @@ PointillisticSynthAudioProcessorEditor::PointillisticSynthAudioProcessorEditor(
       densityPod(ConfigManager::ParamID::density, "Density"),
       durationPod(ConfigManager::ParamID::avgDuration, "Duration"),
       panPod(ConfigManager::ParamID::pan, "Pan") {
+  addAndMakeVisible(visualizationComponent);
   addAndMakeVisible(pitchPod);
   addAndMakeVisible(densityPod);
   addAndMakeVisible(durationPod);
@@ -28,26 +29,16 @@ void PointillisticSynthAudioProcessorEditor::paint(juce::Graphics& g) {
   // Fill the background
   g.fillAll(
       getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
-
-  // You can add drawing code here for the visualization area if needed,
-  // or leave it blank if it's handled by another component.
-  // For now, let's draw a placeholder for the visualization area.
-  auto visArea = getLocalBounds().removeFromTop(getHeight() * 2 / 3);
-  g.setColour(juce::Colours::darkgrey);
-  g.fillRect(visArea);
-  g.setColour(juce::Colours::white);
-  g.drawText("Visualization Area", visArea, juce::Justification::centred,
-             false);
 }
 
 void PointillisticSynthAudioProcessorEditor::resized() {
-  auto bounds = getLocalBounds();
+  auto area = getLocalBounds();
 
-  // Top two-thirds for visualization (currently empty or placeholder)
-  bounds.removeFromTop(getHeight() * 2 / 3);
+  auto visArea = area.removeFromTop(getHeight() * 2 / 3);
+  visualizationComponent.setBounds(visArea);
 
   // Bottom third for the pods
-  auto podArea = bounds;
+  auto podArea = area;
   auto podWidth = podArea.getWidth() / 4;
 
   pitchPod.setBounds(podArea.removeFromLeft(podWidth));

--- a/plugin/source/UI/VisualizationComponent.cpp
+++ b/plugin/source/UI/VisualizationComponent.cpp
@@ -1,0 +1,68 @@
+#include "UI/VisualizationComponent.h"
+
+namespace audio_plugin {
+
+namespace {
+inline double currentTimeSeconds() {
+  return juce::Time::getMillisecondCounterHiRes() / 1000.0;
+}
+}  // namespace
+
+VisualizationComponent::VisualizationComponent() {
+  openGLContext.attachTo(*this);
+  startTimerHz(60);  // 60 FPS
+}
+
+VisualizationComponent::~VisualizationComponent() {
+  stopTimer();
+  openGLContext.detach();
+}
+
+void VisualizationComponent::timerCallback() {
+  const double now = currentTimeSeconds();
+
+  grains.erase(std::remove_if(grains.begin(), grains.end(),
+                              [now](const MockGrain& g) {
+                                return now - g.startTime > g.maxAge;
+                              }),
+               grains.end());
+
+  juce::Random r;
+  if (grains.size() < 256) {
+    int toAdd = r.nextInt(5);  // 0-4 grains
+    for (int i = 0; i < toAdd && grains.size() < 256; ++i) {
+      MockGrain g;
+      g.pan = r.nextFloat() * 2.0f - 1.0f;
+      g.pitch = 21.0f + r.nextFloat() * (108.0f - 21.0f);
+      g.size = 2.0f + r.nextFloat() * 4.0f;
+      float hue = r.nextFloat();
+      float sat = 0.8f + r.nextFloat() * 0.2f;
+      float val = 0.8f + r.nextFloat() * 0.2f;
+      g.colour = juce::Colour::fromHSV(hue, sat, val, 1.0f);
+      g.startTime = now;
+      g.maxAge = 1.0 + static_cast<double>(r.nextFloat()) * 3.0;
+      grains.push_back(g);
+    }
+  }
+
+  repaint();
+}
+
+void VisualizationComponent::paint(juce::Graphics& g) {
+  g.fillAll(juce::Colours::black);
+
+  const int width = getWidth();
+  const int height = getHeight();
+
+  for (const auto& grain : grains) {
+    float x =
+        juce::jmap(grain.pan, -1.0f, 1.0f, 0.0f, static_cast<float>(width));
+    float y = juce::jmap(grain.pitch, 108.0f, 21.0f, 0.0f,
+                         static_cast<float>(height));
+    float diameter = grain.size * 2.0f;
+    g.setColour(grain.colour);
+    g.fillEllipse(x - grain.size, y - grain.size, diameter, diameter);
+  }
+}
+
+}  // namespace audio_plugin

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_SOURCE_FILES
     source/PointilismInterfacesTest.cpp
     source/PresetManagerTest.cpp
     source/UI/PresetBrowserComponentTest.cpp
+    source/UI/VisualizationComponentTest.cpp
     source/ResamplerTest.cpp
 )
 set_source_files_properties(${SOURCE_FILES} PROPERTIES COMPILE_OPTIONS "${PROJECT_WARNINGS_CXX}")

--- a/test/source/UI/VisualizationComponentTest.cpp
+++ b/test/source/UI/VisualizationComponentTest.cpp
@@ -1,0 +1,15 @@
+#include "UI/VisualizationComponent.h"
+#include <gtest/gtest.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace audio_plugin {
+
+struct VisualizationComponentTestFixture : public ::testing::Test {
+  juce::ScopedJuceInitialiser_GUI libraryInitialiser;
+};
+
+TEST_F(VisualizationComponentTestFixture, CanConstruct) {
+  EXPECT_NO_THROW(VisualizationComponent comp);
+}
+
+}  // namespace audio_plugin


### PR DESCRIPTION
## Summary
- implement VisualizationComponent using OpenGL for accelerated drawing
- integrate VisualizationComponent into the plugin editor layout
- register new sources and headers in CMake and link juce_opengl
- add unit test for VisualizationComponent

## Testing
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`
- `clang-tidy plugin/source/UI/VisualizationComponent.cpp plugin/source/PluginEditor.cpp test/source/UI/VisualizationComponentTest.cpp -p build` *(fails: unknown warning options)*

------
https://chatgpt.com/codex/tasks/task_e_68506493785883239e729fcc336afcbb