### PR TITLE
Wire DebugUIPanel to configuration and add listener test

### DIFF
--- a/plugin/include/Pointilsynth/ConfigManager.h
+++ b/plugin/include/Pointilsynth/ConfigManager.h
@@ -34,8 +34,9 @@ public:
   void releaseAttachment(juce::Slider* slider);
   void releaseAttachment(juce::ComboBox* box);
 
-private:
   juce::AudioProcessorValueTreeState& getAPVTS();
+
+private:
   class FunctionListener : public juce::AudioProcessorValueTreeState::Listener {
   public:
     explicit FunctionListener(Callback fn) : fn_(std::move(fn)) {}

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -14,6 +14,7 @@ PointillisticSynthAudioProcessorEditor::PointillisticSynthAudioProcessorEditor(
       durationPod(ConfigManager::ParamID::avgDuration, "Duration"),
       panPod(ConfigManager::ParamID::pan, "Pan") {
   addAndMakeVisible(visualizationComponent);
+  addAndMakeVisible(debugUIPanel);
   addAndMakeVisible(pitchPod);
   addAndMakeVisible(densityPod);
   addAndMakeVisible(durationPod);
@@ -34,10 +35,12 @@ void PointillisticSynthAudioProcessorEditor::paint(juce::Graphics& g) {
 void PointillisticSynthAudioProcessorEditor::resized() {
   auto area = getLocalBounds();
 
-  auto visArea = area.removeFromTop(getHeight() * 2 / 3);
+  auto visArea = area.removeFromTop(getHeight() / 3);
   visualizationComponent.setBounds(visArea);
 
-  // Bottom third for the pods
+  auto debugArea = area.removeFromTop(getHeight() / 3);
+  debugUIPanel.setBounds(debugArea);
+
   auto podArea = area;
   auto podWidth = podArea.getWidth() / 4;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TEST_SOURCE_FILES
     source/PluginEditorTest.cpp
     source/PluginProcessorTest.cpp
     source/PointilismInterfacesTest.cpp
+    source/StochasticModelListenerTest.cpp
     source/PresetManagerTest.cpp
     source/UI/PresetBrowserComponentTest.cpp
     source/UI/VisualizationComponentTest.cpp

--- a/test/source/StochasticModelListenerTest.cpp
+++ b/test/source/StochasticModelListenerTest.cpp
@@ -1,0 +1,19 @@
+#include "Pointilsynth/PointilismInterfaces.h"
+#include "Pointilsynth/PluginProcessor.h"
+#include "Pointilsynth/ConfigManager.h"
+#include <gtest/gtest.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+TEST(StochasticModelListenerTest, UpdatesOnParameterChange) {
+  juce::ScopedJuceInitialiser_GUI libraryInitialiser;
+  audio_plugin::AudioPluginAudioProcessor processor;
+  auto cfg = ConfigManager::getInstance(&processor);
+  StochasticModel model(cfg);
+
+  auto& apvts = cfg->getAPVTS();
+  if (auto* param = apvts.getParameter(ConfigManager::ParamID::pitch)) {
+    param->setValueNotifyingHost(param->convertTo0to1(80.0f));
+  }
+
+  EXPECT_FLOAT_EQ(model.getPitch(), 80.0f);
+}


### PR DESCRIPTION
## Summary
- show DebugUIPanel in the plugin editor and lay it out
- expose `ConfigManager::getAPVTS` so tests can update parameters
- verify parameter listeners with `StochasticModelListenerTest`

## Testing
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`


------
https://chatgpt.com/codex/tasks/task_e_68509978aa2c83238bf47d76a006facd