### PR TITLE
Connect visualization to audio engine

### DIFF
--- a/plugin/include/Pointilsynth/PluginEditor.h
+++ b/plugin/include/Pointilsynth/PluginEditor.h
@@ -4,6 +4,7 @@
 #include "DebugUIPanel.h"     // Added for DebugUIPanel
 #include "PodComponent.h"     // Placeholder pod controls
 #include "UI/VisualizationComponent.h"
+#include <juce_core/juce_core.h>
 // PointilismInterfaces.h is included by PluginProcessor.h, which is included
 // above. If direct use of StochasticModel type was needed here, an include
 // would be good: #include "../../source/PointilismInterfaces.h"
@@ -13,8 +14,10 @@ namespace audio_plugin {
 class PointillisticSynthAudioProcessorEditor
     : public juce::AudioProcessorEditor {
 public:
-  explicit PointillisticSynthAudioProcessorEditor(
-      audio_plugin::AudioPluginAudioProcessor&);
+  PointillisticSynthAudioProcessorEditor(
+      audio_plugin::AudioPluginAudioProcessor&,
+      juce::AbstractFifo& fifo,
+      GrainInfoForVis* buffer);
   ~PointillisticSynthAudioProcessorEditor() override;
 
   void paint(juce::Graphics&) override;

--- a/plugin/include/Pointilsynth/PluginProcessor.h
+++ b/plugin/include/Pointilsynth/PluginProcessor.h
@@ -3,6 +3,7 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 #include "PointilismInterfaces.h"  // Added for AudioEngine and StochasticModel
 #include "ConfigManager.h"
+#include <array>
 
 namespace audio_plugin {
 class AudioPluginAudioProcessor : public juce::AudioProcessor {
@@ -45,7 +46,11 @@ public:
 private:
   std::shared_ptr<ConfigManager> configManager;
   AudioEngine audioEngine;  // Added AudioEngine member
-  std::atomic<int> activeMidiNote_ {-1};
+  std::atomic<int> activeMidiNote_{-1};
+
+  static constexpr int kVisualizationFifoSize = 512;
+  juce::AbstractFifo visualizationFifo{kVisualizationFifoSize};
+  std::array<GrainInfoForVis, kVisualizationFifoSize> visualizationBuffer{};
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)
 };

--- a/plugin/include/Pointilsynth/PluginProcessor.h
+++ b/plugin/include/Pointilsynth/PluginProcessor.h
@@ -45,12 +45,11 @@ public:
 
 private:
   std::shared_ptr<ConfigManager> configManager;
-  AudioEngine audioEngine;  // Added AudioEngine member
-  std::atomic<int> activeMidiNote_{-1};
-
   static constexpr int kVisualizationFifoSize = 512;
   juce::AbstractFifo visualizationFifo{kVisualizationFifoSize};
   std::array<GrainInfoForVis, kVisualizationFifoSize> visualizationBuffer{};
+  AudioEngine audioEngine;  // Added AudioEngine member
+  std::atomic<int> activeMidiNote_{-1};
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)
 };

--- a/plugin/include/Pointilsynth/PointilismInterfaces.h
+++ b/plugin/include/Pointilsynth/PointilismInterfaces.h
@@ -37,6 +37,16 @@ struct Grain {
 };
 
 /**
+ * @struct GrainInfoForVis
+ * @brief Lightweight data passed from the AudioEngine to the GUI thread.
+ */
+struct GrainInfoForVis {
+  float pan{};
+  float pitch{};
+  float durationSeconds{};
+};
+
+/**
  * @class StochasticModel
  * @brief Manages the probability distributions that govern grain creation.
  *
@@ -226,7 +236,9 @@ class AudioEngine {
 public:
   enum class GrainSourceType { Oscillator, AudioSample };
 
-  explicit AudioEngine(std::shared_ptr<ConfigManager> cfg = {});
+  explicit AudioEngine(std::shared_ptr<ConfigManager> cfg = {},
+                       juce::AbstractFifo* visFifo = nullptr,
+                       GrainInfoForVis* visBuffer = nullptr);
 
   /** Called by the host to prepare the engine for playback. */
   void prepareToPlay(double sampleRate, int samplesPerBlock);
@@ -272,6 +284,9 @@ private:
   Pointilsynth::Oscillator oscillator_;
   GrainEnvelope grainEnvelope_;
   std::atomic<GrainSourceType> currentSourceType_{GrainSourceType::Oscillator};
+
+  juce::AbstractFifo* visualizationFifo_{};
+  GrainInfoForVis* visualizationBuffer_{};
 
   void triggerNewGrain();
 };

--- a/plugin/include/UI/VisualizationComponent.h
+++ b/plugin/include/UI/VisualizationComponent.h
@@ -2,19 +2,20 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_opengl/juce_opengl.h>
+#include "Pointilsynth/PointilismInterfaces.h"
 
 namespace audio_plugin {
 
 class VisualizationComponent : public juce::Component, public juce::Timer {
 public:
-  VisualizationComponent();
+  VisualizationComponent(juce::AbstractFifo& fifo, GrainInfoForVis* buffer);
   ~VisualizationComponent() override;
 
   void paint(juce::Graphics& g) override;
   void timerCallback() override;
 
 private:
-  struct MockGrain {
+  struct VisualGrain {
     float pan{};    // -1.0 to 1.0
     float pitch{};  // 21.0 to 108.0
     float size{};   // pixel radius
@@ -24,7 +25,9 @@ private:
   };
 
   juce::OpenGLContext openGLContext;
-  std::vector<MockGrain> grains;
+  std::vector<VisualGrain> grains;
+  juce::AbstractFifo& fifo_;
+  GrainInfoForVis* buffer_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(VisualizationComponent)
 };

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -5,14 +5,17 @@
 namespace audio_plugin {
 
 PointillisticSynthAudioProcessorEditor::PointillisticSynthAudioProcessorEditor(
-    audio_plugin::AudioPluginAudioProcessor& p)
+    audio_plugin::AudioPluginAudioProcessor& p,
+    juce::AbstractFifo& fifo,
+    GrainInfoForVis* buffer)
     : juce::AudioProcessorEditor(&p),
       processorRef(p),
       debugUIPanel(processorRef.getConfigManager()),
       pitchPod(ConfigManager::ParamID::pitch, "Pitch"),
       densityPod(ConfigManager::ParamID::density, "Density"),
       durationPod(ConfigManager::ParamID::avgDuration, "Duration"),
-      panPod(ConfigManager::ParamID::pan, "Pan") {
+      panPod(ConfigManager::ParamID::pan, "Pan"),
+      visualizationComponent(fifo, buffer) {
   addAndMakeVisible(visualizationComponent);
   addAndMakeVisible(debugUIPanel);
   addAndMakeVisible(pitchPod);

--- a/plugin/source/UI/VisualizationComponent.cpp
+++ b/plugin/source/UI/VisualizationComponent.cpp
@@ -41,7 +41,7 @@ void VisualizationComponent::timerCallback() {
     g.size = 4.0f;
     g.colour = juce::Colours::white;
     g.startTime = now;
-    g.maxAge = info.durationSeconds;
+    g.maxAge = static_cast<double>(info.durationSeconds);
     grains.push_back(g);
   }
 

--- a/plugin/source/UI/VisualizationComponent.cpp
+++ b/plugin/source/UI/VisualizationComponent.cpp
@@ -8,7 +8,9 @@ inline double currentTimeSeconds() {
 }
 }  // namespace
 
-VisualizationComponent::VisualizationComponent() {
+VisualizationComponent::VisualizationComponent(juce::AbstractFifo& fifo,
+                                               GrainInfoForVis* buffer)
+    : fifo_(fifo), buffer_(buffer) {
   openGLContext.attachTo(*this);
   startTimerHz(60);  // 60 FPS
 }
@@ -22,27 +24,25 @@ void VisualizationComponent::timerCallback() {
   const double now = currentTimeSeconds();
 
   grains.erase(std::remove_if(grains.begin(), grains.end(),
-                              [now](const MockGrain& g) {
+                              [now](const VisualGrain& g) {
                                 return now - g.startTime > g.maxAge;
                               }),
                grains.end());
-
-  juce::Random r;
-  if (grains.size() < 256) {
-    int toAdd = r.nextInt(5);  // 0-4 grains
-    for (int i = 0; i < toAdd && grains.size() < 256; ++i) {
-      MockGrain g;
-      g.pan = r.nextFloat() * 2.0f - 1.0f;
-      g.pitch = 21.0f + r.nextFloat() * (108.0f - 21.0f);
-      g.size = 2.0f + r.nextFloat() * 4.0f;
-      float hue = r.nextFloat();
-      float sat = 0.8f + r.nextFloat() * 0.2f;
-      float val = 0.8f + r.nextFloat() * 0.2f;
-      g.colour = juce::Colour::fromHSV(hue, sat, val, 1.0f);
-      g.startTime = now;
-      g.maxAge = 1.0 + static_cast<double>(r.nextFloat()) * 3.0;
-      grains.push_back(g);
-    }
+  int start1, size1, start2, size2;
+  while (true) {
+    fifo_.prepareToRead(1, start1, size1, start2, size2);
+    if (size1 == 0)
+      break;
+    GrainInfoForVis info = buffer_[start1];
+    fifo_.finishedRead(size1);
+    VisualGrain g;
+    g.pan = info.pan;
+    g.pitch = info.pitch;
+    g.size = 4.0f;
+    g.colour = juce::Colours::white;
+    g.startTime = now;
+    g.maxAge = info.durationSeconds;
+    grains.push_back(g);
   }
 
   repaint();

--- a/test/source/PluginEditorTest.cpp
+++ b/test/source/PluginEditorTest.cpp
@@ -1,24 +1,28 @@
-#include "Pointilsynth/PluginEditor.h" // Defines audio_plugin::PointillisticSynthAudioProcessorEditor
-#include "Pointilsynth/PluginProcessor.h" // For audio_plugin::AudioPluginAudioProcessor
+#include "Pointilsynth/PluginEditor.h"  // Defines audio_plugin::PointillisticSynthAudioProcessorEditor
+#include "Pointilsynth/PluginProcessor.h"  // For audio_plugin::AudioPluginAudioProcessor
 #include <gtest/gtest.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
 namespace audio_plugin {
 // Minimal ScopedJuceInitialiser_GUI for tests needing it.
 struct JuceGuiTestFixture : public ::testing::Test {
-    JuceGuiTestFixture() = default;
-    juce::ScopedJuceInitialiser_GUI libraryInitialiser;
+  JuceGuiTestFixture() = default;
+  juce::ScopedJuceInitialiser_GUI libraryInitialiser;
 };
 
 // Test fixture for PluginEditor that needs a PluginProcessor
 class PluginEditorTest : public JuceGuiTestFixture {
 protected:
-    AudioPluginAudioProcessor processor; // Create a processor instance
+  AudioPluginAudioProcessor processor;  // Create a processor instance
+  juce::AbstractFifo fifo{8};
+  std::array<GrainInfoForVis, 8> buffer{};
+
 public:
-    PluginEditorTest() = default; // processor is default constructed
+  PluginEditorTest() = default;  // processor is default constructed
 };
 
 TEST_F(PluginEditorTest, CanConstruct) {
-    EXPECT_NO_THROW(std::make_unique<PointillisticSynthAudioProcessorEditor>(processor));
+  EXPECT_NO_THROW(std::make_unique<PointillisticSynthAudioProcessorEditor>(
+      processor, fifo, buffer.data()));
 }
-} // namespace audio_plugin
+}  // namespace audio_plugin

--- a/test/source/UI/VisualizationComponentTest.cpp
+++ b/test/source/UI/VisualizationComponentTest.cpp
@@ -6,10 +6,12 @@ namespace audio_plugin {
 
 struct VisualizationComponentTestFixture : public ::testing::Test {
   juce::ScopedJuceInitialiser_GUI libraryInitialiser;
+  juce::AbstractFifo fifo{8};
+  std::array<GrainInfoForVis, 8> buffer{};
 };
 
 TEST_F(VisualizationComponentTestFixture, CanConstruct) {
-  EXPECT_NO_THROW(VisualizationComponent comp);
+  EXPECT_NO_THROW(VisualizationComponent comp(fifo, buffer.data()));
 }
 
 }  // namespace audio_plugin


### PR DESCRIPTION
## Summary
- add `GrainInfoForVis` struct to pass grain data to the UI
- maintain a lock-free FIFO in `PluginProcessor` for visualization data
- push grain info to the FIFO in `AudioEngine`
- read from the FIFO in `VisualizationComponent` instead of using random grains
- pass the FIFO through `PluginProcessor` -> `Editor` -> `VisualizationComponent`
- update unit tests for new constructors

## Testing
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`


------
https://chatgpt.com/codex/tasks/task_e_6850a4a0043083239ae0df3d9eeab55d