### PR TITLE
Replace limiter with compressor

### DIFF
--- a/plugin/include/Pointilsynth/PluginProcessor.h
+++ b/plugin/include/Pointilsynth/PluginProcessor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_dsp/juce_dsp.h>
 #include "PointilismInterfaces.h"  // Added for AudioEngine and StochasticModel
 #include "ConfigManager.h"
 #include <array>
@@ -50,6 +51,7 @@ private:
   std::array<GrainInfoForVis, kVisualizationFifoSize> visualizationBuffer{};
   AudioEngine audioEngine;  // Added AudioEngine member
   std::atomic<int> activeMidiNote_{-1};
+  juce::dsp::Compressor<float> outputCompressor;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)
 };


### PR DESCRIPTION
## Summary
- add JUCE dsp `Compressor` as the final stage of `PluginProcessor`
- set up compressor during `prepareToPlay`
- reset compressor resources when releasing

## Testing
- `pre-commit run --files plugin/include/Pointilsynth/PluginProcessor.h plugin/source/PluginProcessor.cpp`
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`


------
https://chatgpt.com/codex/tasks/task_e_6850e84433a883238360ac60e5409041