### PR TITLE
Migrate tests to Catch2

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,23 @@
 cmake_minimum_required(VERSION 3.22)
 project(PointilSynthTests VERSION 0.1.0)
 
+cpmaddpackage(
+  NAME
+  Catch2
+  GITHUB_REPOSITORY
+  catchorg/Catch2
+  VERSION
+  3.5.2
+  OPTIONS
+  "CATCH_INSTALL_DOCS OFF"
+  "CATCH_INSTALL_EXTRAS OFF"
+)
+
+list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
+
 enable_testing()
-include(GoogleTest) # For GTest::gtest_main and gtest_discover_tests
+include(CTest)
+include(Catch)
 
 set(TEST_SOURCE_FILES
     source/DebugUIPanelTest.cpp
@@ -39,21 +54,16 @@ target_link_libraries(
          juce::juce_recommended_lto_flags
          juce::juce_audio_processors
          nlohmann_json::nlohmann_json
-  PRIVATE PointillisticSynth GTest::gtest_main
+  PRIVATE PointillisticSynth Catch2::Catch2WithMain
 )
 # juce::juce_recommended_warning_flags
 
 target_include_directories(
-  ${PROJECT_NAME} PRIVATE ${GOOGLETEST_SOURCE_DIR}/googletest/include "${CMAKE_CURRENT_SOURCE_DIR}/../plugin/include"
-                          "${CMAKE_CURRENT_SOURCE_DIR}/.."
+  ${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../plugin/include" "${CMAKE_CURRENT_SOURCE_DIR}/.."
 )
 target_sources(${PROJECT_NAME} PRIVATE ${TEST_SOURCE_FILES})
 
 # Removed: set_source_files_properties(${TEST_SOURCE_FILES} PROPERTIES COMPILE_OPTIONS "${PROJECT_WARNINGS_CXX}")
 # JUCE toolchain should handle appropriate warnings.
 
-if(CMAKE_GENERATOR STREQUAL Xcode)
-  gtest_discover_tests(${PROJECT_NAME} DISCOVERY_MODE PRE_TEST)
-else()
-  gtest_discover_tests(${PROJECT_NAME})
-endif()
+catch_discover_tests(${PROJECT_NAME})

--- a/test/source/DebugUIPanelTest.cpp
+++ b/test/source/DebugUIPanelTest.cpp
@@ -1,12 +1,12 @@
 #include "Pointilsynth/DebugUIPanel.h"
 #include "Pointilsynth/PluginProcessor.h"
 #include "Pointilsynth/ConfigManager.h"
-#include <gtest/gtest.h>
+#include <catch2/catch_test_macros.hpp>
 #include <juce_gui_basics/juce_gui_basics.h>
 
-TEST(DebugUIPanelTest, CanConstruct) {
+TEST_CASE("CanConstruct", "[DebugUIPanelTest]") {
   juce::ScopedJuceInitialiser_GUI libraryInitialiser;
   audio_plugin::AudioPluginAudioProcessor processor;
   auto cfg = ConfigManager::getInstance(&processor);
-  EXPECT_NO_THROW(std::make_unique<DebugUIPanel>(cfg));
+  REQUIRE_NOTHROW(std::make_unique<DebugUIPanel>(cfg));
 }

--- a/test/source/GrainEnvelopeTest.cpp
+++ b/test/source/GrainEnvelopeTest.cpp
@@ -1,6 +1,6 @@
 #include "Pointilsynth/GrainEnvelope.h"
-#include <gtest/gtest.h>
+#include <catch2/catch_test_macros.hpp>
 
-TEST(GrainEnvelopeTest, CanConstruct) {
-    EXPECT_NO_THROW(std::make_unique<GrainEnvelope>());
+TEST_CASE("CanConstruct", "[GrainEnvelopeTest]") {
+  REQUIRE_NOTHROW(std::make_unique<GrainEnvelope>());
 }

--- a/test/source/InertialHistoryManagerTest.cpp
+++ b/test/source/InertialHistoryManagerTest.cpp
@@ -1,14 +1,16 @@
 #include "Pointilsynth/InertialHistoryManager.h"
-#include <gtest/gtest.h>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 
-TEST(InertialHistoryManagerTest, DecaysAndRemovesNotes) {
+TEST_CASE("DecaysAndRemovesNotes", "[InertialHistoryManagerTest]") {
   InertialHistoryManager manager;
   manager.addNote(60, 1.0f, 0.0);
 
   manager.update(4.0, 4.0);  // one bar
-  ASSERT_EQ(manager.getNumNotes(), 1u);
-  EXPECT_NEAR(manager.getNote(0).currentInfluence, 0.5f, 1e-5f);
+  REQUIRE(manager.getNumNotes() == 1u);
+  REQUIRE(manager.getNote(0).currentInfluence ==
+          Catch::Approx(0.5f).margin(1e-5f));
 
   manager.update(16.0, 4.0);  // four bars
-  EXPECT_EQ(manager.getNumNotes(), 0u);
+  REQUIRE(manager.getNumNotes() == 0u);
 }

--- a/test/source/OscillatorTest.cpp
+++ b/test/source/OscillatorTest.cpp
@@ -1,6 +1,6 @@
-#include "Pointilsynth/Oscillator.h" // Defines Pointilsynth::Oscillator
-#include <gtest/gtest.h>
+#include "Pointilsynth/Oscillator.h"  // Defines Pointilsynth::Oscillator
+#include <catch2/catch_test_macros.hpp>
 
-TEST(OscillatorTest, CanConstruct) {
-    EXPECT_NO_THROW(std::make_unique<Pointilsynth::Oscillator>());
+TEST_CASE("CanConstruct", "[OscillatorTest]") {
+  REQUIRE_NOTHROW(std::make_unique<Pointilsynth::Oscillator>());
 }

--- a/test/source/PluginEditorTest.cpp
+++ b/test/source/PluginEditorTest.cpp
@@ -1,11 +1,11 @@
 #include "Pointilsynth/PluginEditor.h"  // Defines audio_plugin::PointillisticSynthAudioProcessorEditor
 #include "Pointilsynth/PluginProcessor.h"  // For audio_plugin::AudioPluginAudioProcessor
-#include <gtest/gtest.h>
+#include <catch2/catch_test_macros.hpp>
 #include <juce_gui_basics/juce_gui_basics.h>
 
 namespace audio_plugin {
 // Minimal ScopedJuceInitialiser_GUI for tests needing it.
-struct JuceGuiTestFixture : public ::testing::Test {
+struct JuceGuiTestFixture {
   JuceGuiTestFixture() = default;
   juce::ScopedJuceInitialiser_GUI libraryInitialiser;
 };
@@ -21,8 +21,8 @@ public:
   PluginEditorTest() = default;  // processor is default constructed
 };
 
-TEST_F(PluginEditorTest, CanConstruct) {
-  EXPECT_NO_THROW(std::make_unique<PointillisticSynthAudioProcessorEditor>(
+TEST_CASE_METHOD(PluginEditorTest, "CanConstruct", "[PluginEditorTest]") {
+  REQUIRE_NOTHROW(std::make_unique<PointillisticSynthAudioProcessorEditor>(
       processor, fifo, buffer.data()));
 }
 }  // namespace audio_plugin

--- a/test/source/PluginProcessorTest.cpp
+++ b/test/source/PluginProcessorTest.cpp
@@ -1,19 +1,22 @@
-#include "Pointilsynth/PluginProcessor.h" // Defines audio_plugin::AudioPluginAudioProcessor
-#include <gtest/gtest.h>
-#include <juce_gui_basics/juce_gui_basics.h> // For ScopedJuceInitialiser_GUI, as PluginProcessor creates an Editor
+#include "Pointilsynth/PluginProcessor.h"  // Defines audio_plugin::AudioPluginAudioProcessor
+#include <catch2/catch_test_macros.hpp>
+#include <juce_gui_basics/juce_gui_basics.h>  // For ScopedJuceInitialiser_GUI, as PluginProcessor creates an Editor
 
-namespace audio_plugin { // Match namespace of class under test for consistency
+namespace audio_plugin {  // Match namespace of class under test for consistency
 
 // Test fixture for PluginProcessor tests if GUI resources are involved
-// (e.g. if the processor's constructor or tested methods use MessageManager or create UI elements)
-// PluginProcessor::createEditor() implies GUI context might be needed.
-struct ProcessorTestFixture : public ::testing::Test {
-    ProcessorTestFixture() = default;
-    juce::ScopedJuceInitialiser_GUI libraryInitialiser;
+// (e.g. if the processor's constructor or tested methods use MessageManager or
+// create UI elements) PluginProcessor::createEditor() implies GUI context might
+// be needed.
+struct ProcessorTestFixture {
+  ProcessorTestFixture() = default;
+  juce::ScopedJuceInitialiser_GUI libraryInitialiser;
 };
 
-TEST_F(ProcessorTestFixture, CanConstructProcessor) { // Renamed test, using fixture
-    EXPECT_NO_THROW(std::make_unique<AudioPluginAudioProcessor>());
+TEST_CASE_METHOD(ProcessorTestFixture,
+                 "CanConstructProcessor",
+                 "[ProcessorTestFixture]") {
+  REQUIRE_NOTHROW(std::make_unique<AudioPluginAudioProcessor>());
 }
 
-} // namespace audio_plugin
+}  // namespace audio_plugin

--- a/test/source/PointilismInterfacesTest.cpp
+++ b/test/source/PointilismInterfacesTest.cpp
@@ -1,16 +1,16 @@
-#include "Pointilsynth/PointilismInterfaces.h" // Defines Grain, StochasticModel, AudioEngine
-#include <gtest/gtest.h>
+#include "Pointilsynth/PointilismInterfaces.h"  // Defines Grain, StochasticModel, AudioEngine
+#include <catch2/catch_test_macros.hpp>
 
-TEST(PointilismInterfacesTest, CanConstructGrain) {
-    EXPECT_NO_THROW(Grain grain);
-    Grain g{}; // Aggregate initialization
-    EXPECT_EQ(g.isAlive, true); // Check default value
+TEST_CASE("CanConstructGrain", "[PointilismInterfacesTest]") {
+  REQUIRE_NOTHROW(Grain{});
+  Grain g{};                   // Aggregate initialization
+  REQUIRE(g.isAlive == true);  // Check default value
 }
 
-TEST(PointilismInterfacesTest, CanConstructStochasticModel) {
-    EXPECT_NO_THROW(std::make_unique<StochasticModel>());
+TEST_CASE("CanConstructStochasticModel", "[PointilismInterfacesTest]") {
+  REQUIRE_NOTHROW(std::make_unique<StochasticModel>());
 }
 
-TEST(PointilismInterfacesTest, CanConstructAudioEngine) {
-    EXPECT_NO_THROW(std::make_unique<AudioEngine>());
+TEST_CASE("CanConstructAudioEngine", "[PointilismInterfacesTest]") {
+  REQUIRE_NOTHROW(std::make_unique<AudioEngine>());
 }

--- a/test/source/PresetManagerTest.cpp
+++ b/test/source/PresetManagerTest.cpp
@@ -1,8 +1,8 @@
-#include "Pointilsynth/PresetManager.h" // Defines Pointilism::PresetManager
-#include "Pointilsynth/PointilismInterfaces.h" // For StochasticModel
-#include <gtest/gtest.h>
+#include "Pointilsynth/PresetManager.h"  // Defines Pointilism::PresetManager
+#include "Pointilsynth/PointilismInterfaces.h"  // For StochasticModel
+#include <catch2/catch_test_macros.hpp>
 
-TEST(PresetManagerTest, CanConstruct) {
-    StochasticModel model;
-    EXPECT_NO_THROW(std::make_unique<Pointilism::PresetManager>(model));
+TEST_CASE("CanConstruct", "[PresetManagerTest]") {
+  StochasticModel model;
+  REQUIRE_NOTHROW(std::make_unique<Pointilism::PresetManager>(model));
 }

--- a/test/source/ResamplerTest.cpp
+++ b/test/source/ResamplerTest.cpp
@@ -1,17 +1,17 @@
-#include "Pointilsynth/Resampler.h" // Defines Resampler namespace
-#include <gtest/gtest.h>
-#include <juce_audio_basics/juce_audio_basics.h> // For juce::AudioBuffer
+#include "Pointilsynth/Resampler.h"  // Defines Resampler namespace
+#include <catch2/catch_test_macros.hpp>
+#include <juce_audio_basics/juce_audio_basics.h>  // For juce::AudioBuffer
 
-TEST(ResamplerTest, CanIncludeAndCallSinc) {
-    // Simple test to ensure compilation and basic call
-    double val = 0.5;
-    EXPECT_NO_THROW(Resampler::sinc(val));
-    // A more robust test might check the value, but for now, no throw is enough.
+TEST_CASE("CanIncludeAndCallSinc", "[ResamplerTest]") {
+  // Simple test to ensure compilation and basic call
+  double val = 0.5;
+  REQUIRE_NOTHROW(Resampler::sinc(val));
+  // A more robust test might check the value, but for now, no throw is enough.
 }
 
-TEST(ResamplerTest, GetSampleRuns) {
-    juce::AudioBuffer<float> buffer(1, 100); // 1 channel, 100 samples
-    buffer.clear(); // Fill with zeros
-    // Test with some basic parameters
-    EXPECT_NO_THROW(Resampler::getSample(buffer, 0, 10.5));
+TEST_CASE("GetSampleRuns", "[ResamplerTest]") {
+  juce::AudioBuffer<float> buffer(1, 100);  // 1 channel, 100 samples
+  buffer.clear();                           // Fill with zeros
+  // Test with some basic parameters
+  REQUIRE_NOTHROW(Resampler::getSample(buffer, 0, 10.5));
 }

--- a/test/source/StandaloneGrainEnvelopeTest.cpp
+++ b/test/source/StandaloneGrainEnvelopeTest.cpp
@@ -1,21 +1,26 @@
 #include "GrainEnvelope.h"
-#include <gtest/gtest.h>
+#include <juce_core/juce_core.h>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 
-TEST(StandaloneGrainEnvelopeTest, HannShapeReturnsExpectedValues) {
+TEST_CASE("HannShapeReturnsExpectedValues", "[StandaloneGrainEnvelopeTest]") {
   GrainEnvelope env;
   env.setShape(GrainEnvelope::Shape::Hann);
   const int duration = 100;
-  EXPECT_FLOAT_EQ(env.getAmplitude(0, duration), 0.0f);
-  EXPECT_NEAR(env.getAmplitude(duration / 2, duration), 1.0f, 1e-6f);
-  EXPECT_NEAR(env.getAmplitude(duration - 1, duration), 0.0f, 1e-2f);
+  REQUIRE(juce::approximatelyEqual(env.getAmplitude(0, duration), 0.0f));
+  REQUIRE(env.getAmplitude(duration / 2, duration) ==
+          Catch::Approx(1.0f).margin(1e-6f));
+  REQUIRE(env.getAmplitude(duration - 1, duration) ==
+          Catch::Approx(0.0f).margin(1e-2f));
 }
 
-TEST(StandaloneGrainEnvelopeTest, TrapezoidShapeReturnsExpectedValues) {
+TEST_CASE("TrapezoidShapeReturnsExpectedValues",
+          "[StandaloneGrainEnvelopeTest]") {
   GrainEnvelope env;
   env.setShape(GrainEnvelope::Shape::Trapezoid);
   const int duration = 100;
-  EXPECT_FLOAT_EQ(env.getAmplitude(0, duration), 0.0f);
-  EXPECT_FLOAT_EQ(env.getAmplitude(10, duration), 1.0f);
-  EXPECT_FLOAT_EQ(env.getAmplitude(50, duration), 1.0f);
-  EXPECT_NEAR(env.getAmplitude(99, duration), 0.1f, 1e-6f);
+  REQUIRE(juce::approximatelyEqual(env.getAmplitude(0, duration), 0.0f));
+  REQUIRE(juce::approximatelyEqual(env.getAmplitude(10, duration), 1.0f));
+  REQUIRE(juce::approximatelyEqual(env.getAmplitude(50, duration), 1.0f));
+  REQUIRE(env.getAmplitude(99, duration) == Catch::Approx(0.1f).margin(1e-6f));
 }

--- a/test/source/StochasticModelListenerTest.cpp
+++ b/test/source/StochasticModelListenerTest.cpp
@@ -1,10 +1,10 @@
 #include "Pointilsynth/PointilismInterfaces.h"
 #include "Pointilsynth/PluginProcessor.h"
 #include "Pointilsynth/ConfigManager.h"
-#include <gtest/gtest.h>
+#include <catch2/catch_test_macros.hpp>
 #include <juce_gui_basics/juce_gui_basics.h>
 
-TEST(StochasticModelListenerTest, UpdatesOnParameterChange) {
+TEST_CASE("UpdatesOnParameterChange", "[StochasticModelListenerTest]") {
   juce::ScopedJuceInitialiser_GUI libraryInitialiser;
   audio_plugin::AudioPluginAudioProcessor processor;
   auto cfg = ConfigManager::getInstance(&processor);
@@ -15,5 +15,5 @@ TEST(StochasticModelListenerTest, UpdatesOnParameterChange) {
     param->setValueNotifyingHost(param->convertTo0to1(80.0f));
   }
 
-  EXPECT_FLOAT_EQ(model.getPitch(), 80.0f);
+  REQUIRE(juce::approximatelyEqual(model.getPitch(), 80.0f));
 }

--- a/test/source/UI/PodComponentTest.cpp
+++ b/test/source/UI/PodComponentTest.cpp
@@ -1,17 +1,19 @@
 #include "PodComponent.h"  // Defines audio_plugin::PodComponent
 #include "Pointilsynth/ConfigManager.h"
-#include <gtest/gtest.h>
+#include <catch2/catch_test_macros.hpp>
 #include <juce_gui_basics/juce_gui_basics.h>  // For ScopedJuceInitialiser_GUI
 
 namespace audio_plugin {
 // Minimal ScopedJuceInitialiser_GUI for tests needing it.
-struct JuceGuiTestFixture : public ::testing::Test {
+struct JuceGuiTestFixture {
   JuceGuiTestFixture() = default;
   juce::ScopedJuceInitialiser_GUI libraryInitialiser;
 };
 
-TEST_F(JuceGuiTestFixture, PodComponentCanConstruct) {
-  EXPECT_NO_THROW(
+TEST_CASE_METHOD(JuceGuiTestFixture,
+                 "PodComponentCanConstruct",
+                 "[PodComponent]") {
+  REQUIRE_NOTHROW(
       std::make_unique<PodComponent>(ConfigManager::ParamID::pitch, "Pitch"));
 }
 }  // namespace audio_plugin

--- a/test/source/UI/PresetBrowserComponentTest.cpp
+++ b/test/source/UI/PresetBrowserComponentTest.cpp
@@ -2,22 +2,24 @@
 #include "Pointilsynth/PresetManager.h"
 #include "Pointilsynth/PointilismInterfaces.h"
 #include "Pointilsynth/PluginProcessor.h"
-#include <gtest/gtest.h>
+#include <catch2/catch_test_macros.hpp>
 #include <juce_gui_basics/juce_gui_basics.h>
 
 namespace audio_plugin {
 
-struct PresetBrowserTestFixture : public ::testing::Test {
+struct PresetBrowserTestFixture {
   PresetBrowserTestFixture() = default;
   juce::ScopedJuceInitialiser_GUI libraryInitialiser;
 };
 
-TEST_F(PresetBrowserTestFixture, CanConstruct) {
+TEST_CASE_METHOD(PresetBrowserTestFixture,
+                 "CanConstruct",
+                 "[PresetBrowserTestFixture]") {
   AudioPluginAudioProcessor processor;
   auto cfg = ConfigManager::getInstance(&processor);
   StochasticModel model(cfg);
   Pointilism::PresetManager manager(model);
-  EXPECT_NO_THROW(PresetBrowserComponent browser(manager));
+  REQUIRE_NOTHROW([&] { PresetBrowserComponent browser(manager); }());
 }
 
 }  // namespace audio_plugin

--- a/test/source/UI/VisualizationComponentTest.cpp
+++ b/test/source/UI/VisualizationComponentTest.cpp
@@ -1,17 +1,19 @@
 #include "UI/VisualizationComponent.h"
-#include <gtest/gtest.h>
+#include <catch2/catch_test_macros.hpp>
 #include <juce_gui_basics/juce_gui_basics.h>
 
 namespace audio_plugin {
 
-struct VisualizationComponentTestFixture : public ::testing::Test {
+struct VisualizationComponentTestFixture {
   juce::ScopedJuceInitialiser_GUI libraryInitialiser;
   juce::AbstractFifo fifo{8};
   std::array<GrainInfoForVis, 8> buffer{};
 };
 
-TEST_F(VisualizationComponentTestFixture, CanConstruct) {
-  EXPECT_NO_THROW(VisualizationComponent comp(fifo, buffer.data()));
+TEST_CASE_METHOD(VisualizationComponentTestFixture,
+                 "CanConstruct",
+                 "[VisualizationComponentTestFixture]") {
+  REQUIRE_NOTHROW([&] { VisualizationComponent comp(fifo, buffer.data()); }());
 }
 
 }  // namespace audio_plugin


### PR DESCRIPTION
## Summary
- switch test framework from GoogleTest to Catch2
- add Catch2 via CPM in test/CMakeLists
- convert all tests to Catch2 syntax

## Testing
- `pre-commit run --files test/CMakeLists.txt test/source/DebugUIPanelTest.cpp test/source/GrainEnvelopeTest.cpp test/source/InertialHistoryManagerTest.cpp test/source/OscillatorTest.cpp test/source/PluginEditorTest.cpp test/source/PluginProcessorTest.cpp test/source/PointilismInterfacesTest.cpp test/source/PresetManagerTest.cpp test/source/ResamplerTest.cpp test/source/StandaloneGrainEnvelopeTest.cpp test/source/StochasticModelListenerTest.cpp test/source/UI/PodComponentTest.cpp test/source/UI/PresetBrowserComponentTest.cpp test/source/UI/VisualizationComponentTest.cpp`
- `cmake --preset default`
- `cmake --build --preset default -j4`
- `ctest --preset default`

------
https://chatgpt.com/codex/tasks/task_e_685259bdcc70832383c2eaec1f6bf5c9