### PR TITLE
Integrate melatonin_test_helpers and add silence test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,32 @@ cpmaddpackage(
   "CATCH_INSTALL_EXTRAS OFF"
 )
 
+cpmaddpackage(
+  NAME
+  melatonin_audio_sparklines
+  GITHUB_REPOSITORY
+  sudara/melatonin_audio_sparklines
+  GIT_TAG
+  main
+  DOWNLOAD_ONLY TRUE
+)
+set(SPARKLINES_MODULE_PATH ${CMAKE_BINARY_DIR}/melatonin_audio_sparklines)
+file(COPY ${melatonin_audio_sparklines_SOURCE_DIR}/ DESTINATION ${SPARKLINES_MODULE_PATH})
+juce_add_module(${SPARKLINES_MODULE_PATH})
+
+cpmaddpackage(
+  NAME
+  melatonin_test_helpers
+  GITHUB_REPOSITORY
+  sudara/melatonin_test_helpers
+  GIT_TAG
+  main
+  DOWNLOAD_ONLY TRUE
+)
+set(TEST_HELPERS_MODULE_PATH ${CMAKE_BINARY_DIR}/melatonin_test_helpers)
+file(COPY ${melatonin_test_helpers_SOURCE_DIR}/ DESTINATION ${TEST_HELPERS_MODULE_PATH})
+juce_add_module(${TEST_HELPERS_MODULE_PATH})
+
 list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
 
 enable_testing()
@@ -24,6 +50,7 @@ set(TEST_SOURCE_FILES
     source/GrainEnvelopeTest.cpp
     source/StandaloneGrainEnvelopeTest.cpp
     source/OscillatorTest.cpp
+    source/AudioEngineTest.cpp
     source/PluginEditorTest.cpp
     source/PluginProcessorTest.cpp
     source/PointilismInterfacesTest.cpp
@@ -55,6 +82,11 @@ target_link_libraries(
          juce::juce_audio_processors
          nlohmann_json::nlohmann_json
   PRIVATE PointillisticSynth Catch2::Catch2WithMain
+        melatonin_test_helpers
+)
+target_compile_definitions(
+  ${PROJECT_NAME}
+  PRIVATE JUCE_MODAL_LOOPS_PERMITTED=1
 )
 # juce::juce_recommended_warning_flags
 

--- a/test/source/AudioEngineTest.cpp
+++ b/test/source/AudioEngineTest.cpp
@@ -1,0 +1,23 @@
+#include "Pointilsynth/PluginProcessor.h"
+#include "melatonin_test_helpers/melatonin_test_helpers.h"
+#include <catch2/catch_test_macros.hpp>
+
+using namespace audio_plugin;
+using namespace melatonin;
+
+TEST_CASE("AudioEngine: Silence") {
+  juce::ScopedJuceInitialiser_GUI libraryInitialiser;
+  AudioPluginAudioProcessor processor;
+  auto cfg = processor.getConfigManager();
+  auto& apvts = cfg->getAPVTS();
+  if (auto* param = apvts.getParameter(ConfigManager::ParamID::density)) {
+    param->setValueNotifyingHost(param->convertTo0to1(0.0f));
+  }
+  AudioEngine engine(cfg);
+  engine.prepareToPlay(44100.0, 512);
+  juce::AudioBuffer<float> buffer(2, 512);
+  juce::MidiBuffer midi;
+  juce::AudioPlayHead::PositionInfo pos;
+  engine.processBlock(buffer, midi, pos);
+  REQUIRE_THAT(buffer, isEmpty());
+}


### PR DESCRIPTION
## Summary
- integrate melatonin_test_helpers and its dependency melatonin_audio_sparklines
- add AudioEngineTest.cpp verifying silent output when density is zero
- enable JUCE_MODAL_LOOPS_PERMITTED for tests

## Testing
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`

------
https://chatgpt.com/codex/tasks/task_e_6852624c43c48323afd5609ea2ac70bd