### PR TITLE
Implement modulation summing with inertial notes

### DIFF
--- a/plugin/include/Pointilsynth/InertialHistoryManager.h
+++ b/plugin/include/Pointilsynth/InertialHistoryManager.h
@@ -7,6 +7,7 @@ struct InertialNote {
   float initialInfluence{};
   float currentInfluence{};
   double startPpq{};
+  double ageInBars{};
 };
 
 class InertialHistoryManager {

--- a/plugin/source/InertialHistoryManager.cpp
+++ b/plugin/source/InertialHistoryManager.cpp
@@ -11,12 +11,14 @@ void InertialHistoryManager::addNote(int noteNumber,
   note.initialInfluence = velocity;
   note.currentInfluence = velocity;
   note.startPpq = currentPpq;
+  note.ageInBars = 0.0;
   notes_.push_back(note);
 }
 
 void InertialHistoryManager::update(double currentPpq, double ppqPerBar) {
   for (auto it = notes_.begin(); it != notes_.end();) {
     double ageInBars = (currentPpq - it->startPpq) / ppqPerBar;
+    it->ageInBars = ageInBars;
     it->currentInfluence =
         it->initialInfluence * static_cast<float>(std::pow(0.5, ageInBars));
     if (it->currentInfluence < it->initialInfluence * 0.125f) {
@@ -28,5 +30,12 @@ void InertialHistoryManager::update(double currentPpq, double ppqPerBar) {
 }
 
 float InertialHistoryManager::getModulationValue() {
-  return 0.0f;
+  float totalModulation = 0.0f;
+  for (const auto& note : notes_) {
+    float lfo = std::sin(static_cast<float>(note.ageInBars) * 2.0f *
+                         static_cast<float>(M_PI)) *
+                note.currentInfluence;
+    totalModulation += lfo;
+  }
+  return totalModulation;
 }

--- a/test/source/InertialHistoryManagerTest.cpp
+++ b/test/source/InertialHistoryManagerTest.cpp
@@ -14,3 +14,26 @@ TEST_CASE("DecaysAndRemovesNotes", "[InertialHistoryManagerTest]") {
   manager.update(16.0, 4.0);  // four bars
   REQUIRE(manager.getNumNotes() == 0u);
 }
+
+TEST_CASE("ModulationValueOscillatesAndDecays",
+          "[InertialHistoryManagerTest]") {
+  InertialHistoryManager manager;
+  manager.addNote(60, 1.0f, 0.0);
+
+  manager.update(1.0, 4.0);  // quarter note
+  float first = manager.getModulationValue();
+  REQUIRE(std::abs(first) > 0.001f);
+
+  manager.update(3.0, 4.0);  // three quarter notes
+  float second = manager.getModulationValue();
+  REQUIRE(std::abs(second) > 0.001f);
+  REQUIRE(first * second < 0.0f);  // oscillation should change sign
+
+  manager.update(7.0, 4.0);  // nearly two bars
+  float third = manager.getModulationValue();
+  REQUIRE(std::abs(third) < std::abs(first));
+
+  manager.update(16.0, 4.0);  // four bars, note removed
+  float final = manager.getModulationValue();
+  REQUIRE(final == Catch::Approx(0.0f).margin(1e-5f));
+}


### PR DESCRIPTION
## Summary
- store each note's age in `InertialNote`
- sum per-note LFOs in `InertialHistoryManager::getModulationValue`
- verify oscillating modulation output via new unit test

## Testing
- `cmake --preset default`
- `cmake --build --preset default --target PointilSynthTests -j4`
- `ctest --preset default`

------
https://chatgpt.com/codex/tasks/task_e_685262c00204832393f1619704835d9b