### PR TITLE
Add debug UI window

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SOURCE_FILES
     source/InertialHistoryManager.cpp
     source/ConfigManager.cpp
     source/DebugUIPanel.cpp
+    source/DebugUIWindow.cpp
     source/PluginProcessor.cpp
     source/PluginEditor.cpp
     source/PresetManager.cpp
@@ -57,6 +58,7 @@ set(SOURCE_FILES
 # Optional; includes header files in the project file tree in Visual Studio
 set(HEADER_FILES
     ${INCLUDE_DIR}/DebugUIPanel.h
+    ${INCLUDE_DIR}/DebugUIWindow.h
     ${INCLUDE_DIR}/ConfigManager.h
     ${INCLUDE_DIR}/GrainEnvelope.h
     ${INCLUDE_DIR}/Oscillator.h

--- a/plugin/include/Pointilsynth/DebugUIWindow.h
+++ b/plugin/include/Pointilsynth/DebugUIWindow.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "DebugUIPanel.h"
+#include "ConfigManager.h"
+#include <functional>
+
+class DebugUIWindow : public juce::DocumentWindow {
+public:
+  DebugUIWindow(std::shared_ptr<ConfigManager> cfg,
+                std::function<void()> onClose);
+  void closeButtonPressed() override;
+
+private:
+  DebugUIPanel debugUIPanel_;
+  std::function<void()> onClose_;
+  JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DebugUIWindow)
+};

--- a/plugin/include/Pointilsynth/PluginEditor.h
+++ b/plugin/include/Pointilsynth/PluginEditor.h
@@ -2,6 +2,7 @@
 
 #include "PluginProcessor.h"  // Adjusted path
 #include "DebugUIPanel.h"     // Added for DebugUIPanel
+#include "DebugUIWindow.h"    // For launching separate debug window
 #include "PodComponent.h"     // Placeholder pod controls
 #include "UI/VisualizationComponent.h"
 #include <juce_core/juce_core.h>
@@ -29,6 +30,11 @@ private:
   audio_plugin::AudioPluginAudioProcessor& processorRef;
 
   DebugUIPanel debugUIPanel;  // Added DebugUIPanel member
+
+  void openDebugWindow();
+
+  juce::TextButton openDebugButton{"Open Debug UI"};
+  std::unique_ptr<DebugUIWindow> debugWindow;
 
   PodComponent pitchPod;
   PodComponent densityPod;

--- a/plugin/source/DebugUIWindow.cpp
+++ b/plugin/source/DebugUIWindow.cpp
@@ -1,0 +1,20 @@
+#include "Pointilsynth/DebugUIWindow.h"
+
+DebugUIWindow::DebugUIWindow(std::shared_ptr<ConfigManager> cfg,
+                             std::function<void()> onClose)
+    : DocumentWindow("Debug UI",
+                     juce::Colours::darkgrey,
+                     juce::DocumentWindow::allButtons),
+      debugUIPanel_(std::move(cfg)),
+      onClose_(std::move(onClose)) {
+  setUsingNativeTitleBar(true);
+  setResizable(true, true);
+  setContentOwned(&debugUIPanel_, false);
+  centreWithSize(600, 400);
+}
+
+void DebugUIWindow::closeButtonPressed() {
+  if (onClose_)
+    onClose_();
+  setVisible(false);
+}

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -22,6 +22,8 @@ PointillisticSynthAudioProcessorEditor::PointillisticSynthAudioProcessorEditor(
   addAndMakeVisible(densityPod);
   addAndMakeVisible(durationPod);
   addAndMakeVisible(panPod);
+  addAndMakeVisible(openDebugButton);
+  openDebugButton.onClick = [this] { openDebugWindow(); };
 
   setSize(600, 400);  // Example size, can be adjusted
 }
@@ -45,12 +47,22 @@ void PointillisticSynthAudioProcessorEditor::resized() {
   debugUIPanel.setBounds(debugArea);
 
   auto podArea = area;
+  auto buttonArea = podArea.removeFromBottom(30);
+  openDebugButton.setBounds(buttonArea.reduced(4));
   auto podWidth = podArea.getWidth() / 4;
 
   pitchPod.setBounds(podArea.removeFromLeft(podWidth));
   densityPod.setBounds(podArea.removeFromLeft(podWidth));
   durationPod.setBounds(podArea.removeFromLeft(podWidth));
   panPod.setBounds(podArea);
+}
+
+void PointillisticSynthAudioProcessorEditor::openDebugWindow() {
+  if (debugWindow)
+    return;
+  debugWindow = std::make_unique<DebugUIWindow>(
+      processorRef.getConfigManager(), [this] { debugWindow.reset(); });
+  debugWindow->setVisible(true);
 }
 
 }  // namespace audio_plugin


### PR DESCRIPTION
## Summary
- add a `DebugUIWindow` class that shows a detachable debug UI
- open this window from a new button in `PluginEditor`

## Testing
- `pre-commit run --files plugin/CMakeLists.txt plugin/include/Pointilsynth/PluginEditor.h plugin/source/PluginEditor.cpp plugin/include/Pointilsynth/DebugUIWindow.h plugin/source/DebugUIWindow.cpp`
- `cmake --build --preset default`
- `ctest --preset default`


------
https://chatgpt.com/codex/tasks/task_e_6854a13bee208323b5bff492745c820c