### PR TITLE
Add popup window for Debug UI

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SOURCE_FILES
     source/InertialHistoryManager.cpp
     source/ConfigManager.cpp
     source/DebugUIPanel.cpp
+    source/DebugWindow.cpp
     source/PluginProcessor.cpp
     source/PluginEditor.cpp
     source/PresetManager.cpp
@@ -57,6 +58,7 @@ set(SOURCE_FILES
 # Optional; includes header files in the project file tree in Visual Studio
 set(HEADER_FILES
     ${INCLUDE_DIR}/DebugUIPanel.h
+    ${INCLUDE_DIR}/DebugWindow.h
     ${INCLUDE_DIR}/ConfigManager.h
     ${INCLUDE_DIR}/GrainEnvelope.h
     ${INCLUDE_DIR}/Oscillator.h

--- a/plugin/include/Pointilsynth/DebugWindow.h
+++ b/plugin/include/Pointilsynth/DebugWindow.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "DebugUIPanel.h"
+#include "ConfigManager.h"
+
+class DebugWindow : public juce::DocumentWindow {
+public:
+  explicit DebugWindow(std::shared_ptr<ConfigManager> cfg);
+  ~DebugWindow() override = default;
+
+  void closeButtonPressed() override;
+
+private:
+  JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DebugWindow)
+};

--- a/plugin/include/Pointilsynth/PluginEditor.h
+++ b/plugin/include/Pointilsynth/PluginEditor.h
@@ -2,6 +2,7 @@
 
 #include "PluginProcessor.h"  // Adjusted path
 #include "DebugUIPanel.h"     // Added for DebugUIPanel
+#include "DebugWindow.h"      // Popup window for DebugUIPanel
 #include "PodComponent.h"     // Placeholder pod controls
 #include "UI/VisualizationComponent.h"
 #include <juce_core/juce_core.h>
@@ -28,7 +29,8 @@ private:
   // access the processor object that created it.
   audio_plugin::AudioPluginAudioProcessor& processorRef;
 
-  DebugUIPanel debugUIPanel;  // Added DebugUIPanel member
+  juce::TextButton debugButton{"Open Debug"};
+  std::unique_ptr<DebugWindow> debugWindow;
 
   PodComponent pitchPod;
   PodComponent densityPod;

--- a/plugin/source/DebugWindow.cpp
+++ b/plugin/source/DebugWindow.cpp
@@ -1,0 +1,16 @@
+#include "Pointilsynth/DebugWindow.h"
+
+DebugWindow::DebugWindow(std::shared_ptr<ConfigManager> cfg)
+    : juce::DocumentWindow("Debug",
+                           juce::Colours::lightgrey,
+                           juce::DocumentWindow::allButtons) {
+  setUsingNativeTitleBar(true);
+  setResizable(true, true);
+  setAlwaysOnTop(true);
+  setContentOwned(new DebugUIPanel(std::move(cfg)), true);
+  centreWithSize(400, 300);
+}
+
+void DebugWindow::closeButtonPressed() {
+  setVisible(false);
+}

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -1,6 +1,7 @@
 #include "Pointilsynth/PluginEditor.h"
 #include "Pointilsynth/PluginProcessor.h"  // Ensure this path is correct based on include directories
 #include "Pointilsynth/ConfigManager.h"
+#include "Pointilsynth/DebugWindow.h"
 
 namespace audio_plugin {
 
@@ -10,18 +11,25 @@ PointillisticSynthAudioProcessorEditor::PointillisticSynthAudioProcessorEditor(
     GrainInfoForVis* buffer)
     : juce::AudioProcessorEditor(&p),
       processorRef(p),
-      debugUIPanel(processorRef.getConfigManager()),
       pitchPod(ConfigManager::ParamID::pitch, "Pitch"),
       densityPod(ConfigManager::ParamID::density, "Density"),
       durationPod(ConfigManager::ParamID::avgDuration, "Duration"),
       panPod(ConfigManager::ParamID::pan, "Pan"),
       visualizationComponent(fifo, buffer) {
   addAndMakeVisible(visualizationComponent);
-  addAndMakeVisible(debugUIPanel);
+  addAndMakeVisible(debugButton);
   addAndMakeVisible(pitchPod);
   addAndMakeVisible(densityPod);
   addAndMakeVisible(durationPod);
   addAndMakeVisible(panPod);
+
+  debugButton.onClick = [this] {
+    if (!debugWindow)
+      debugWindow =
+          std::make_unique<DebugWindow>(processorRef.getConfigManager());
+    debugWindow->setVisible(true);
+    debugWindow->toFront(true);
+  };
 
   setSize(600, 400);  // Example size, can be adjusted
 }
@@ -41,8 +49,8 @@ void PointillisticSynthAudioProcessorEditor::resized() {
   auto visArea = area.removeFromTop(getHeight() / 3);
   visualizationComponent.setBounds(visArea);
 
-  auto debugArea = area.removeFromTop(getHeight() / 3);
-  debugUIPanel.setBounds(debugArea);
+  auto buttonArea = area.removeFromTop(30);
+  debugButton.setBounds(buttonArea.reduced(5));
 
   auto podArea = area;
   auto podWidth = podArea.getWidth() / 4;


### PR DESCRIPTION
## Summary
- add DebugWindow to show DebugUIPanel in a new top-level window
- launch DebugWindow from a new button in PluginEditor
- ensure debug window floats above the main editor

## Testing
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`
- `clang-tidy -p build plugin/source/DebugWindow.cpp` *(fails: unknown warning options)*
- `clang-tidy -p build plugin/source/PluginEditor.cpp` *(fails: unknown warning options)*

------
https://chatgpt.com/codex/tasks/task_e_6855a90d14248323a71d519ca8306ac3