### PR TITLE
Add inertial history visualizer UI

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SOURCE_FILES
     source/PresetManager.cpp
     source/UI/PresetBrowserComponent.cpp
     source/UI/VisualizationComponent.cpp
+    source/UI/InertialHistoryVisualizer.cpp
     source/PodComponent.cpp
     source/StochasticModel.cpp
 )
@@ -70,6 +71,7 @@ set(HEADER_FILES
     ${INCLUDE_DIR}/Resampler.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/UI/PresetBrowserComponent.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/UI/VisualizationComponent.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/UI/InertialHistoryVisualizer.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/PodComponent.h
 )
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCE_FILES} ${HEADER_FILES})

--- a/plugin/include/UI/InertialHistoryVisualizer.h
+++ b/plugin/include/UI/InertialHistoryVisualizer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <deque>
+#include <vector>
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "Pointilsynth/InertialHistoryManager.h"
+
+namespace audio_plugin {
+
+class InertialHistoryVisualizer : public juce::Component, private juce::Timer {
+public:
+  explicit InertialHistoryVisualizer(InertialHistoryManager& manager);
+  ~InertialHistoryVisualizer() override = default;
+
+  void paint(juce::Graphics& g) override;
+
+private:
+  void timerCallback() override;
+
+  InertialHistoryManager& manager_;
+  std::vector<std::deque<float>> histories_;
+
+  static constexpr int maxPoints_ = 128;
+};
+
+}  // namespace audio_plugin

--- a/plugin/source/UI/InertialHistoryVisualizer.cpp
+++ b/plugin/source/UI/InertialHistoryVisualizer.cpp
@@ -1,0 +1,78 @@
+#include "UI/InertialHistoryVisualizer.h"
+
+#include <cmath>
+
+namespace audio_plugin {
+
+InertialHistoryVisualizer::InertialHistoryVisualizer(
+    InertialHistoryManager& manager)
+    : manager_(manager) {
+  startTimerHz(30);
+}
+
+void InertialHistoryVisualizer::timerCallback() {
+  const size_t noteCount = manager_.getNumNotes();
+  if (histories_.size() < noteCount)
+    histories_.resize(noteCount);
+
+  for (size_t i = 0; i < noteCount; ++i) {
+    const auto& note = manager_.getNote(i);
+    const float value = std::sin(static_cast<float>(note.ageInBars) *
+                                 juce::MathConstants<float>::twoPi) *
+                        note.currentInfluence;
+    auto& hist = histories_[i];
+    hist.push_back(value);
+    if (static_cast<int>(hist.size()) > maxPoints_)
+      hist.pop_front();
+  }
+  for (size_t i = noteCount; i < histories_.size(); ++i) {
+    auto& hist = histories_[i];
+    hist.push_back(0.0f);
+    if (static_cast<int>(hist.size()) > maxPoints_)
+      hist.pop_front();
+  }
+
+  repaint();
+}
+
+void InertialHistoryVisualizer::paint(juce::Graphics& g) {
+  g.fillAll(juce::Colours::black);
+  const int width = getWidth();
+  const int height = getHeight();
+
+  if (histories_.empty())
+    return;
+
+  const size_t historyPoints = histories_.front().size();
+  if (historyPoints < 2)
+    return;
+
+  std::vector<float> baseline(historyPoints, 0.0f);
+  const float scale = static_cast<float>(height) / 4.0f;
+  const float xStep =
+      static_cast<float>(width) / static_cast<float>(maxPoints_ - 1);
+
+  for (size_t i = 0; i < histories_.size(); ++i) {
+    const auto& hist = histories_[i];
+    if (hist.empty())
+      continue;
+
+    juce::Path p;
+    for (size_t j = 0; j < historyPoints; ++j) {
+      baseline[j] += hist[j];
+      const float x = static_cast<float>(j) * xStep;
+      const float y = static_cast<float>(height) / 2.0f - baseline[j] * scale;
+      if (j == 0)
+        p.startNewSubPath(x, y);
+      else
+        p.lineTo(x, y);
+    }
+    juce::Colour colour = juce::Colour::fromHSV(
+        static_cast<float>(i) / static_cast<float>(histories_.size()), 0.7f,
+        0.9f, 1.0f);
+    g.setColour(colour);
+    g.strokePath(p, juce::PathStrokeType(1.0f));
+  }
+}
+
+}  // namespace audio_plugin

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,7 +20,8 @@ cpmaddpackage(
   sudara/melatonin_audio_sparklines
   GIT_TAG
   main
-  DOWNLOAD_ONLY TRUE
+  DOWNLOAD_ONLY
+  TRUE
 )
 set(SPARKLINES_MODULE_PATH ${CMAKE_BINARY_DIR}/melatonin_audio_sparklines)
 file(COPY ${melatonin_audio_sparklines_SOURCE_DIR}/ DESTINATION ${SPARKLINES_MODULE_PATH})
@@ -33,7 +34,8 @@ cpmaddpackage(
   sudara/melatonin_test_helpers
   GIT_TAG
   main
-  DOWNLOAD_ONLY TRUE
+  DOWNLOAD_ONLY
+  TRUE
 )
 set(TEST_HELPERS_MODULE_PATH ${CMAKE_BINARY_DIR}/melatonin_test_helpers)
 file(COPY ${melatonin_test_helpers_SOURCE_DIR}/ DESTINATION ${TEST_HELPERS_MODULE_PATH})
@@ -58,6 +60,7 @@ set(TEST_SOURCE_FILES
     source/PresetManagerTest.cpp
     source/UI/PresetBrowserComponentTest.cpp
     source/UI/VisualizationComponentTest.cpp
+    source/UI/InertialHistoryVisualizerTest.cpp
     source/ResamplerTest.cpp
     source/InertialHistoryManagerTest.cpp
 )
@@ -81,13 +84,9 @@ target_link_libraries(
          juce::juce_recommended_lto_flags
          juce::juce_audio_processors
          nlohmann_json::nlohmann_json
-  PRIVATE PointillisticSynth Catch2::Catch2WithMain
-        melatonin_test_helpers
+  PRIVATE PointillisticSynth Catch2::Catch2WithMain melatonin_test_helpers
 )
-target_compile_definitions(
-  ${PROJECT_NAME}
-  PRIVATE JUCE_MODAL_LOOPS_PERMITTED=1
-)
+target_compile_definitions(${PROJECT_NAME} PRIVATE JUCE_MODAL_LOOPS_PERMITTED=1)
 # juce::juce_recommended_warning_flags
 
 target_include_directories(

--- a/test/source/UI/InertialHistoryVisualizerTest.cpp
+++ b/test/source/UI/InertialHistoryVisualizerTest.cpp
@@ -1,0 +1,26 @@
+#include "UI/InertialHistoryVisualizer.h"
+#include <catch2/catch_test_macros.hpp>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+using audio_plugin::InertialHistoryVisualizer;
+
+struct InertialHistoryVisualizerFixture {
+  juce::ScopedJuceInitialiser_GUI libraryInitialiser;
+  InertialHistoryManager manager;
+};
+
+TEST_CASE_METHOD(InertialHistoryVisualizerFixture,
+                 "CanConstruct",
+                 "[InertialHistoryVisualizer]") {
+  REQUIRE_NOTHROW([&] { InertialHistoryVisualizer comp(manager); }());
+}
+
+TEST_CASE_METHOD(InertialHistoryVisualizerFixture,
+                 "PaintDoesNotCrash",
+                 "[InertialHistoryVisualizer]") {
+  InertialHistoryVisualizer comp(manager);
+  comp.setBounds(0, 0, 100, 50);
+  juce::Image img(juce::Image::RGB, 100, 50, true);
+  juce::Graphics g(img);
+  REQUIRE_NOTHROW([&] { comp.paint(g); }());
+}


### PR DESCRIPTION
## Summary
- visualize contributions of `InertialHistoryManager` using stacked sparklines
- include new component in build
- test that the component can construct and paint

## Testing
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --preset default`

------
https://chatgpt.com/codex/tasks/task_e_6855ee417b78832385f0e41daa4d541e